### PR TITLE
Support TupleType, RestType and OptionalType in TypeScript 3.0

### DIFF
--- a/packages/@manta-style/runtime/src/index.ts
+++ b/packages/@manta-style/runtime/src/index.ts
@@ -13,8 +13,11 @@ import TypeReference from './types/TypeReference';
 import TypeAliasDeclaration from './nodes/TypeAliasDeclaration';
 import ConditionalType from './types/ConditionalType';
 import KeyOfKeyword from './types/KeyOfKeyword';
-import { Type, Literals, Annotation } from './utils/baseType';
 import ArrayLiteral from './types/ArrayLiteral';
+import TupleType from './types/TupleType';
+import RestType from './types/RestType';
+import OptionalType from './types/OptionalType';
+import { Type, Literals, Annotation } from './utils/baseType';
 
 export const URL_QUERY_TYPE_PREFIX = '@@URLQuery/';
 
@@ -82,6 +85,15 @@ class MantaStyle {
   }
   public static ArrayType(elementType: Type) {
     return new ArrayType(elementType);
+  }
+  public static TupleType(elementTypes: Type[]) {
+    return new TupleType(elementTypes);
+  }
+  public static RestType(elementType: Type) {
+    return new RestType(elementType);
+  }
+  public static OptionalType(type: Type) {
+    return new OptionalType(type);
   }
   public static TypeReference(referenceName: string) {
     return new TypeReference(referenceName);

--- a/packages/@manta-style/runtime/src/types/ArrayLiteral.ts
+++ b/packages/@manta-style/runtime/src/types/ArrayLiteral.ts
@@ -6,6 +6,9 @@ export default class ArrayLiteral extends Type {
     super();
     this.elements = elements;
   }
+  public getElements() {
+    return this.elements;
+  }
   public deriveLiteral() {
     return this;
   }

--- a/packages/@manta-style/runtime/src/types/OptionalType.ts
+++ b/packages/@manta-style/runtime/src/types/OptionalType.ts
@@ -1,0 +1,12 @@
+import { Type, Annotation } from '../utils/baseType';
+
+export default class OptionalType extends Type {
+  private type: Type;
+  constructor(type: Type) {
+    super();
+    this.type = type;
+  }
+  public deriveLiteral(annotations?: Annotation[]) {
+    return this.type.deriveLiteral(annotations);
+  }
+}

--- a/packages/@manta-style/runtime/src/types/RestType.ts
+++ b/packages/@manta-style/runtime/src/types/RestType.ts
@@ -1,0 +1,3 @@
+import ArrayType from './ArrayType';
+
+export default class RestType extends ArrayType {}

--- a/packages/@manta-style/runtime/src/types/TupleType.ts
+++ b/packages/@manta-style/runtime/src/types/TupleType.ts
@@ -1,0 +1,26 @@
+import { Type } from '../utils/baseType';
+import ArrayLiteral from './ArrayLiteral';
+import OptionalType from './OptionalType';
+import RestType from './RestType';
+
+export default class TupleType extends Type {
+  private elementTypes: Type[];
+  constructor(elementTypes: Type[]) {
+    super();
+    this.elementTypes = elementTypes;
+  }
+  public deriveLiteral() {
+    const arrayLiteral: Type[] = [];
+    this.elementTypes.forEach((type) => {
+      const chance = type instanceof OptionalType ? Math.random() : 1;
+      if (chance > 0.5) {
+        if (type instanceof RestType) {
+          arrayLiteral.push(...type.deriveLiteral().getElements());
+        } else {
+          arrayLiteral.push(type.deriveLiteral());
+        }
+      }
+    });
+    return new ArrayLiteral(arrayLiteral);
+  }
+}

--- a/packages/@manta-style/typescript-transformer/src/typescript.ts
+++ b/packages/@manta-style/typescript-transformer/src/typescript.ts
@@ -1,0 +1,9 @@
+import * as ts from 'typescript';
+
+export function isOptionalType(node: ts.Node): node is ts.OptionalTypeNode {
+  return node.kind === ts.SyntaxKind.OptionalType;
+}
+
+export function isRestType(node: ts.Node): node is ts.RestTypeNode {
+  return node.kind === ts.SyntaxKind.RestType;
+}

--- a/packages/@manta-style/typescript-transformer/src/utils.ts
+++ b/packages/@manta-style/typescript-transformer/src/utils.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript';
 import { MANTASTYLE_RUNTIME_NAME } from './constants';
+import { isOptionalType, isRestType } from './typescript';
 
 /*
 type X = {
@@ -365,6 +366,22 @@ export function createMantaStyleRuntimeObject(
     return createLiteralType(node);
   } else if (ts.isArrayTypeNode(node)) {
     return createArrayType(node, typeParameters);
+  } else if (ts.isTupleTypeNode(node)) {
+    return createRuntimeFunctionCall('TupleType', [
+      ts.createArrayLiteral(
+        node.elementTypes.map((type) =>
+          createMantaStyleRuntimeObject(type, typeParameters),
+        ),
+      ),
+    ]);
+  } else if (isOptionalType(node)) {
+    return createRuntimeFunctionCall('OptionalType', [
+      createMantaStyleRuntimeObject(node.type, typeParameters),
+    ]);
+  } else if (isRestType(node) && ts.isArrayTypeNode(node.type)) {
+    return createRuntimeFunctionCall('RestType', [
+      createMantaStyleRuntimeObject(node.type.elementType, typeParameters),
+    ]);
   } else if (ts.isConditionalTypeNode(node)) {
     return createRuntimeFunctionCall('ConditionalType', [
       createMantaStyleRuntimeObject(node.checkType, typeParameters),


### PR DESCRIPTION
This PR get following syntaxes supported (new in TypeScript 3.0):
```typescript
type TwoDCoord = [number, number]; // TupleType
type Coord = [number, number, number?]; // OptionalType
type Lists = [number, number, ...string[]]; // RestType
```