### PR TITLE
fix unknown plugin

### DIFF
--- a/packages/@manta-style/typescript-builder/src/utils/build.ts
+++ b/packages/@manta-style/typescript-builder/src/utils/build.ts
@@ -39,7 +39,7 @@ export default function build(
       console.log('[BABEL] Processing file: ' + file);
     }
     const result = babelCore.transformFileSync(file, {
-      plugins: ['transform-es2015-modules-commonjs'],
+      plugins: [require('babel-plugin-transform-es2015-modules-commonjs')],
     });
     fs.writeFileSync(file, result.code);
   }


### PR DESCRIPTION
<img width="1280" alt="screen shot 2018-08-12 at 10 06 57 pm" src="https://user-images.githubusercontent.com/2338632/44003204-7e2c4e48-9e81-11e8-8171-c10771b85d31.png">

will see `ReferenceError: Unknown plugin "transform-es2015-modules-commonjs"`
if the plugin is not installed in the repo. either to add this as `devDependencies` or directly `require` the plugin within `manta-style`.