### PR TITLE
Make annotations inheritable from parents

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "devDependencies": {
     "codecov": "^3.0.4",
-    "lerna": "^3.0.0-beta.21",
-    "prettier": "^1.13.7"
+    "lerna": "^3.0.3",
+    "prettier": "^1.14.2"
   },
   "workspaces": [
     "packages/@manta-style/*"

--- a/packages/@manta-style/cli/package.json
+++ b/packages/@manta-style/cli/package.json
@@ -38,7 +38,7 @@
     "chalk": "^2.4.1",
     "chokidar": "^2.0.4",
     "cli-table": "^0.3.1",
-    "commander": "^2.16.0",
+    "commander": "^2.17.1",
     "express": "^4.16.3",
     "find-root": "^1.1.0",
     "log-update": "^2.3.0",

--- a/packages/@manta-style/cli/src/index.ts
+++ b/packages/@manta-style/cli/src/index.ts
@@ -95,7 +95,7 @@ function buildEndpoints(method: HTTPMethods) {
             MantaStyle.createTypeByQuery(key, query[key]);
           });
         }
-        const literalType = endpoint.type.deriveLiteral();
+        const literalType = endpoint.type.deriveLiteral([]);
         const mockData = literalType.mock();
         if (isSnapshotMode) {
           const snapshotData = snapshot.fetchSnapshot(

--- a/packages/@manta-style/runtime/__mocks__/lodash-es.ts
+++ b/packages/@manta-style/runtime/__mocks__/lodash-es.ts
@@ -17,3 +17,7 @@ export function min(values: number[]) {
     Math.min(prevValue, currentValue),
   );
 }
+
+export function sample<T>(values: T[]) {
+  return values[0];
+}

--- a/packages/@manta-style/runtime/__tests__/types/ArrayType.ts
+++ b/packages/@manta-style/runtime/__tests__/types/ArrayType.ts
@@ -6,11 +6,11 @@ const type = MS.ArrayType(MS.NumberKeyword);
 
 describe('AnyKeyword', () => {
   test('deriveLiteral', () => {
-    const literals = type.deriveLiteral();
+    const literals = type.deriveLiteral([]);
     expect(literals instanceof ArrayLiteral).toBe(true);
   });
   test('mock without annotations', () => {
-    const data = type.deriveLiteral().mock();
+    const data = type.deriveLiteral([]).mock();
     expect(data.every((item) => typeof item === 'number')).toBe(true);
   });
   test('mock with annotation @length', () => {

--- a/packages/@manta-style/runtime/__tests__/types/ConditionalType.ts
+++ b/packages/@manta-style/runtime/__tests__/types/ConditionalType.ts
@@ -18,8 +18,8 @@ describe('ConditionalType', () => {
       literalTrue,
       literalFalse,
     );
-    const expectedTypeNumber = conditionNumber.deriveLiteral();
-    const expectedTypeString = conditionString.deriveLiteral();
+    const expectedTypeNumber = conditionNumber.deriveLiteral([]);
+    const expectedTypeString = conditionString.deriveLiteral([]);
     expect(expectedTypeNumber).toBe(literalTrue);
     expect(expectedTypeString).toBe(literalFalse);
   });

--- a/packages/@manta-style/runtime/__tests__/types/OptionalType.ts
+++ b/packages/@manta-style/runtime/__tests__/types/OptionalType.ts
@@ -7,7 +7,7 @@ describe('OptionalType', () => {
       MS.Literal(2),
       MS.OptionalType(MS.NumberKeyword),
     ]);
-    const result = tuple.deriveLiteral().mock();
+    const result = tuple.deriveLiteral([]).mock();
     expect(result.length === 2 || result.length === 3).toBe(true);
     expect(result[0]).toBe(1);
     expect(result[1]).toBe(2);

--- a/packages/@manta-style/runtime/__tests__/types/RestType.ts
+++ b/packages/@manta-style/runtime/__tests__/types/RestType.ts
@@ -7,7 +7,7 @@ describe('RestType', () => {
       MS.Literal(2),
       MS.RestType(MS.StringKeyword),
     ]);
-    const result = tuple.deriveLiteral().mock();
+    const result = tuple.deriveLiteral([]).mock();
     const [, , ...strings] = result;
     expect(result.length).toBeGreaterThan(2);
     expect(result[0]).toBe(1);

--- a/packages/@manta-style/runtime/__tests__/types/TupleType.ts
+++ b/packages/@manta-style/runtime/__tests__/types/TupleType.ts
@@ -3,6 +3,6 @@ import MS from '../../src';
 describe('TupleType', () => {
   test('mock', () => {
     const tuple = MS.TupleType([MS.Literal(1), MS.Literal(2), MS.Literal(3)]);
-    expect(tuple.deriveLiteral().mock()).toEqual([1, 2, 3]);
+    expect(tuple.deriveLiteral([]).mock()).toEqual([1, 2, 3]);
   });
 });

--- a/packages/@manta-style/runtime/__tests__/types/TypeLiteral.ts
+++ b/packages/@manta-style/runtime/__tests__/types/TypeLiteral.ts
@@ -1,0 +1,26 @@
+import MS from '../../src';
+
+describe('TypeLiteral Test', () => {
+  afterEach(() => {
+    MS.clearType();
+  });
+  test('TypeLiteral can mock', () => {
+    const GenericTypeLiteral = () =>
+      MS.TypeAliasDeclaration(
+        'GenericTypeLiteral',
+        (type) => {
+          const T = type.TypeParameter('T');
+          return MS.TypeLiteral((currentType) => {
+            currentType.property('test', T, false, []);
+          });
+        },
+        [],
+      );
+    MS.registerType('GenericTypeLiteral', GenericTypeLiteral);
+    const TestObject = MS.referenceType('GenericTypeLiteral').argumentTypes([
+      MS.NumberKeyword,
+    ]);
+    const result = TestObject.deriveLiteral([]).mock();
+    expect(typeof result.test === 'number').toBe(true);
+  });
+});

--- a/packages/@manta-style/runtime/__tests__/utils/annotation.ts
+++ b/packages/@manta-style/runtime/__tests__/utils/annotation.ts
@@ -1,8 +1,11 @@
 import { Annotation } from '../../src/utils/baseType';
 import { inheritAnnotations } from '../../src/utils/annotation';
-import MantaStyle from '../../src';
+import MS from '../../src';
 
 describe('Annotation Test', () => {
+  afterEach(() => {
+    MS.clearType();
+  });
   test('Inherit Annotations', () => {
     const parent: Annotation[] = [
       { key: 'length', value: '0' },
@@ -20,15 +23,87 @@ describe('Annotation Test', () => {
     ]);
   });
   test('Array can inherit @length from TypeAliasDeclaration', () => {
-    const type = MantaStyle.TypeAliasDeclaration(
+    const type = MS.TypeAliasDeclaration(
       'Test',
       () => {
-        return MantaStyle.ArrayType(MantaStyle.StringKeyword);
+        return MS.ArrayType(MS.StringKeyword);
       },
       [{ key: 'length', value: '100' }, { key: 'example', value: 'yes' }],
     );
     const result = type.deriveLiteral([]).mock();
     expect(result).toHaveLength(100);
     expect(result).toEqual(Array.from(new Array(100), () => 'yes'));
+  });
+  test('resolveReferencedType could correctly inherit annotations #1', () => {
+    /*
+     * type GenericType<T> = T;
+     * type SingleType = number;
+     * // @length 20
+     * type ArrayType = SingleType[];
+     * type TestObject = GenericType<ArrayType>;
+     */
+    const GenericType = () =>
+      MS.TypeAliasDeclaration(
+        'GenericType',
+        (type) => type.TypeParameter('T'),
+        [],
+      );
+    const SingleType = () =>
+      MS.TypeAliasDeclaration('SingleType', () => MS.NumberKeyword, []);
+    const ArrayType = () =>
+      MS.TypeAliasDeclaration(
+        'ArrayType',
+        () => MS.ArrayType(MS.TypeReference('SingleType')),
+        [{ key: 'length', value: '20' }],
+      );
+    MS.registerType('GenericType', GenericType);
+    MS.registerType('SingleType', SingleType);
+    MS.registerType('ArrayType', ArrayType);
+    const TestObject = MS.TypeAliasDeclaration(
+      'TestObject',
+      () =>
+        MS.TypeReference('GenericType').argumentTypes([
+          MS.TypeReference('ArrayType'),
+        ]),
+      [],
+    );
+    const result = TestObject.deriveLiteral([]).mock();
+    expect(result).toHaveLength(20);
+  });
+  test('resolveReferencedType could correctly inherit annotations #2', () => {
+    /*
+     * type GenericType<T> = T;
+     * type SingleType = number;
+     * type ArrayType = SingleType[];
+     * // @length 20
+     * type TestObject = GenericType<ArrayType>;
+     */
+    const GenericType = () =>
+      MS.TypeAliasDeclaration(
+        'GenericType',
+        (type) => type.TypeParameter('T'),
+        [],
+      );
+    const SingleType = () =>
+      MS.TypeAliasDeclaration('SingleType', () => MS.NumberKeyword, []);
+    const ArrayType = () =>
+      MS.TypeAliasDeclaration(
+        'ArrayType',
+        () => MS.ArrayType(MS.TypeReference('SingleType')),
+        [],
+      );
+    MS.registerType('GenericType', GenericType);
+    MS.registerType('SingleType', SingleType);
+    MS.registerType('ArrayType', ArrayType);
+    const TestObject = MS.TypeAliasDeclaration(
+      'TestObject',
+      () =>
+        MS.TypeReference('GenericType').argumentTypes([
+          MS.TypeReference('ArrayType'),
+        ]),
+      [{ key: 'length', value: '20' }],
+    );
+    const result = TestObject.deriveLiteral([]).mock();
+    expect(result).toHaveLength(20);
   });
 });

--- a/packages/@manta-style/runtime/__tests__/utils/annotation.ts
+++ b/packages/@manta-style/runtime/__tests__/utils/annotation.ts
@@ -1,0 +1,34 @@
+import { Annotation } from '../../src/utils/baseType';
+import { inheritAnnotations } from '../../src/utils/annotation';
+import MantaStyle from '../../src';
+
+describe('Annotation Test', () => {
+  test('Inherit Annotations', () => {
+    const parent: Annotation[] = [
+      { key: 'length', value: '0' },
+      { key: 'length', value: '2' },
+      { key: 'example', value: 'cool' },
+    ];
+    const child: Annotation[] = [{ key: 'length', value: '1' }];
+    const result = inheritAnnotations(parent, child);
+    expect(result).toEqual([
+      {
+        key: 'example',
+        value: 'cool',
+      },
+      { key: 'length', value: '1' },
+    ]);
+  });
+  test('Array can inherit @length from TypeAliasDeclaration', () => {
+    const type = MantaStyle.TypeAliasDeclaration(
+      'Test',
+      () => {
+        return MantaStyle.ArrayType(MantaStyle.StringKeyword);
+      },
+      [{ key: 'length', value: '100' }, { key: 'example', value: 'yes' }],
+    );
+    const result = type.deriveLiteral([]).mock();
+    expect(result).toHaveLength(100);
+    expect(result).toEqual(Array.from(new Array(100), () => 'yes'));
+  });
+});

--- a/packages/@manta-style/runtime/__tests__/utils/intersection.ts
+++ b/packages/@manta-style/runtime/__tests__/utils/intersection.ts
@@ -43,7 +43,7 @@ describe('Intersection Test', () => {
       currentType.property('b', MS.NumberKeyword, false, []);
     });
     const objC = intersection(objA, objB);
-    const mockData = objC.deriveLiteral().mock();
+    const mockData = objC.deriveLiteral([]).mock();
     expect(Object.keys(mockData)).toEqual(['a', 'b']);
   });
 });

--- a/packages/@manta-style/runtime/package.json
+++ b/packages/@manta-style/runtime/package.json
@@ -29,9 +29,9 @@
     "@types/lodash-es": "^4.17.1",
     "jest": "^23.4.2",
     "source-map-loader": "^0.2.3",
-    "ts-jest": "^23.1.0",
+    "ts-jest": "^23.1.3",
     "typescript": "3.0.1",
-    "webpack": "^4.16.3",
+    "webpack": "^4.16.5",
     "webpack-cli": "^3.1.0"
   },
   "dependencies": {

--- a/packages/@manta-style/runtime/src/index.ts
+++ b/packages/@manta-style/runtime/src/index.ts
@@ -30,6 +30,9 @@ class MantaStyle {
   private static typeReferences: {
     [key: string]: TypeAliasDeclarationFactory;
   } = {};
+  public static clearType() {
+    MantaStyle.typeReferences = {};
+  }
   public static registerType(name: string, type: TypeAliasDeclarationFactory) {
     if (MantaStyle.typeReferences[name]) {
       throw new Error(`Type "${name}" has already been registered.`);

--- a/packages/@manta-style/runtime/src/nodes/TypeParameter.ts
+++ b/packages/@manta-style/runtime/src/nodes/TypeParameter.ts
@@ -1,16 +1,16 @@
-import { Type } from '../utils/baseType';
+import { Annotation, Type } from '../utils/baseType';
 import { ErrorType } from '../utils/pseudoTypes';
 import { isAssignable } from '../utils/assignable';
 
 export default class TypeParameter extends Type {
-  private name: string;
+  private readonly name: string;
   private actualType?: Type;
-  private contraintType?: Type;
-  private defaultType: Type;
+  private readonly constraintType?: Type;
+  private readonly defaultType: Type;
   constructor(name: string, constraintType?: Type, defaultType?: Type) {
     super();
     this.name = name;
-    this.contraintType = constraintType;
+    this.constraintType = constraintType;
     this.defaultType =
       defaultType ||
       new ErrorType(
@@ -21,7 +21,7 @@ export default class TypeParameter extends Type {
     return this.name;
   }
   public setActualType(type: Type) {
-    if (this.contraintType && !isAssignable(type, this.contraintType)) {
+    if (this.constraintType && !isAssignable(type, this.constraintType)) {
       throw Error(
         'Constraint is not satisfied. Please check the error message from TypeScript.',
       );
@@ -31,7 +31,7 @@ export default class TypeParameter extends Type {
   public getActualType() {
     return this.actualType || this.defaultType;
   }
-  public deriveLiteral() {
-    return this.getActualType().deriveLiteral();
+  public deriveLiteral(parentAnnotations: Annotation[]) {
+    return this.getActualType().deriveLiteral(parentAnnotations);
   }
 }

--- a/packages/@manta-style/runtime/src/types/ArrayLiteral.ts
+++ b/packages/@manta-style/runtime/src/types/ArrayLiteral.ts
@@ -1,7 +1,7 @@
 import { Type } from '../utils/baseType';
 
 export default class ArrayLiteral extends Type {
-  private elements: Type[];
+  private readonly elements: Type[];
   constructor(elements: Type[]) {
     super();
     this.elements = elements;

--- a/packages/@manta-style/runtime/src/types/ArrayType.ts
+++ b/packages/@manta-style/runtime/src/types/ArrayType.ts
@@ -8,7 +8,7 @@ export default class ArrayType extends Type {
     super();
     this.elementType = elementType;
   }
-  public deriveLiteral(annotations?: Annotation[]) {
+  public deriveLiteral(annotations: Annotation[]) {
     const array: Type[] = [];
     const lengthFromJSDoc = getNumberFromAnnotationKey({
       key: 'length',

--- a/packages/@manta-style/runtime/src/types/BooleanKeyword.ts
+++ b/packages/@manta-style/runtime/src/types/BooleanKeyword.ts
@@ -3,6 +3,6 @@ import Literal from './Literal';
 
 export default class BooleanKeyword extends Type {
   public deriveLiteral() {
-    return new Literal(Math.random() < 0.5 ? false : true);
+    return new Literal(Math.random() >= 0.5);
   }
 }

--- a/packages/@manta-style/runtime/src/types/ConditionalType.ts
+++ b/packages/@manta-style/runtime/src/types/ConditionalType.ts
@@ -21,7 +21,7 @@ export default class ConditionalType extends Type {
     this.trueType = trueType;
     this.falseType = falseType;
   }
-  public deriveLiteral(annotations?: Annotation[]) {
+  public deriveLiteral(annotations: Annotation[]) {
     /*
       From: http://koerbitz.me/posts/a-look-at-typescripts-conditional-types.html
       The Distributive Rule of Conditional and Union Types
@@ -53,7 +53,7 @@ export default class ConditionalType extends Type {
             ),
         ),
       );
-      return resolvedType.deriveLiteral();
+      return resolvedType.deriveLiteral(annotations);
     } else {
       const resolvedType = resolveConditionalType(
         checkType,

--- a/packages/@manta-style/runtime/src/types/ConditionalType.ts
+++ b/packages/@manta-style/runtime/src/types/ConditionalType.ts
@@ -35,9 +35,9 @@ export default class ConditionalType extends Type {
       trueType: maybeReferencedTrueType,
       falseType: maybeReferencedFalseType,
     } = this;
-    const checkType = resolveReferencedType(maybeReferencedCheckType);
-    const trueType = resolveReferencedType(maybeReferencedTrueType);
-    const falseType = resolveReferencedType(maybeReferencedFalseType);
+    const { type: checkType } = resolveReferencedType(maybeReferencedCheckType);
+    const { type: trueType } = resolveReferencedType(maybeReferencedTrueType);
+    const { type: falseType } = resolveReferencedType(maybeReferencedFalseType);
     if (checkType instanceof UnionType) {
       const resolvedType = normalizeUnion(
         new UnionType(

--- a/packages/@manta-style/runtime/src/types/IndexedAccessType.ts
+++ b/packages/@manta-style/runtime/src/types/IndexedAccessType.ts
@@ -1,4 +1,4 @@
-import { Type } from '../utils/baseType';
+import { Annotation, Type } from '../utils/baseType';
 import Literal from './Literal';
 import { resolveReferencedType } from '../utils/referenceTypes';
 import TypeLiteral from './TypeLiteral';
@@ -6,8 +6,8 @@ import UnionType from './UnionType';
 import MantaStyle from '..';
 
 export default class IndexedAccessType extends Type {
-  private objectType: Type;
-  private indexType: Type;
+  private readonly objectType: Type;
+  private readonly indexType: Type;
   constructor(objectType: Type, indexType: Type) {
     super();
     this.objectType = objectType;
@@ -16,21 +16,21 @@ export default class IndexedAccessType extends Type {
   public getProperty() {
     const objType = resolveReferencedType(this.objectType);
     const indexType = resolveReferencedType(this.indexType);
-    const indexName = indexType.deriveLiteral().mock();
+    const indexName = indexType.deriveLiteral([]).mock();
     if (objType instanceof TypeLiteral) {
       return objType
         ._getProperties()
         .find((property) => property.name === indexName);
     }
   }
-  public deriveLiteral() {
+  public deriveLiteral(parentAnnotations: Annotation[]) {
     const {
       objectType: maybeReferencedObjectType,
       indexType: maybeReferencedIndexType,
     } = this;
     const objectType = resolveReferencedType(
       maybeReferencedObjectType,
-    ).deriveLiteral();
+    ).deriveLiteral(parentAnnotations);
     const indexType = resolveReferencedType(maybeReferencedIndexType);
     if (objectType instanceof TypeLiteral) {
       if (indexType instanceof Literal) {
@@ -53,7 +53,7 @@ export default class IndexedAccessType extends Type {
         return new Literal('Unimplemented');
       }
     } else {
-      return objectType.deriveLiteral();
+      return objectType.deriveLiteral(parentAnnotations);
     }
   }
 }

--- a/packages/@manta-style/runtime/src/types/IndexedAccessType.ts
+++ b/packages/@manta-style/runtime/src/types/IndexedAccessType.ts
@@ -14,8 +14,8 @@ export default class IndexedAccessType extends Type {
     this.indexType = indexType;
   }
   public getProperty() {
-    const objType = resolveReferencedType(this.objectType);
-    const indexType = resolveReferencedType(this.indexType);
+    const { type: objType } = resolveReferencedType(this.objectType);
+    const { type: indexType } = resolveReferencedType(this.indexType);
     const indexName = indexType.deriveLiteral([]).mock();
     if (objType instanceof TypeLiteral) {
       return objType
@@ -30,7 +30,7 @@ export default class IndexedAccessType extends Type {
     } = this;
     const objectType = resolveReferencedType(
       maybeReferencedObjectType,
-    ).deriveLiteral(parentAnnotations);
+    ).type.deriveLiteral(parentAnnotations);
     const indexType = resolveReferencedType(maybeReferencedIndexType);
     if (objectType instanceof TypeLiteral) {
       if (indexType instanceof Literal) {

--- a/packages/@manta-style/runtime/src/types/IntersectionType.ts
+++ b/packages/@manta-style/runtime/src/types/IntersectionType.ts
@@ -11,6 +11,7 @@ export default class IntersectionType extends Type {
   public deriveLiteral(parentAnnotations: Annotation[]) {
     const reducedType = this.types
       .map(resolveReferencedType)
+      .map((item) => item.type)
       .reduce((previousType, currentType) =>
         intersection(previousType, currentType),
       );

--- a/packages/@manta-style/runtime/src/types/IntersectionType.ts
+++ b/packages/@manta-style/runtime/src/types/IntersectionType.ts
@@ -1,20 +1,20 @@
-import { Type } from '../utils/baseType';
+import { Annotation, Type } from '../utils/baseType';
 import { resolveReferencedType } from '../utils/referenceTypes';
 import { intersection } from '../utils/intersection';
 
 export default class IntersectionType extends Type {
-  private types: Type[];
+  private readonly types: Type[];
   constructor(types: Type[]) {
     super();
     this.types = types;
   }
-  public deriveLiteral() {
+  public deriveLiteral(parentAnnotations: Annotation[]) {
     const reducedType = this.types
       .map(resolveReferencedType)
       .reduce((previousType, currentType) =>
         intersection(previousType, currentType),
       );
-    return reducedType.deriveLiteral();
+    return reducedType.deriveLiteral(parentAnnotations);
   }
   public getTypes() {
     return this.types;

--- a/packages/@manta-style/runtime/src/types/KeyOfKeyword.ts
+++ b/packages/@manta-style/runtime/src/types/KeyOfKeyword.ts
@@ -12,7 +12,7 @@ export default class KeyOfKeyword extends Type {
   }
   public getKeys(): string[] {
     const { type: maybeReferencedType } = this;
-    const type = resolveReferencedType(maybeReferencedType);
+    const { type }: { type: Type } = resolveReferencedType(maybeReferencedType);
     if (type instanceof TypeLiteral) {
       return type.getKeys();
     } else {

--- a/packages/@manta-style/runtime/src/types/Literal.ts
+++ b/packages/@manta-style/runtime/src/types/Literal.ts
@@ -1,7 +1,7 @@
 import { Literals, Type } from '../utils/baseType';
 
 export default class Literal<T extends Literals> extends Type {
-  private literal: T;
+  private readonly literal: T;
   constructor(literal: T) {
     super();
     this.literal = literal;

--- a/packages/@manta-style/runtime/src/types/MappedType.ts
+++ b/packages/@manta-style/runtime/src/types/MappedType.ts
@@ -32,8 +32,8 @@ export default class MappedType extends Type {
      * }
      */
     const { typeParameter } = this;
-    const constraint = resolveReferencedType(this.constraint);
-    const type = resolveReferencedType(this.type);
+    const { type: constraint } = resolveReferencedType(this.constraint);
+    const { type } = resolveReferencedType(this.type);
     const newTypeLiteral = new TypeLiteral();
     if (
       (constraint instanceof UnionType || constraint instanceof Literal) &&

--- a/packages/@manta-style/runtime/src/types/MappedType.ts
+++ b/packages/@manta-style/runtime/src/types/MappedType.ts
@@ -1,7 +1,7 @@
 import { QuestionToken } from '@manta-style/consts';
 import TypeParameter from '../nodes/TypeParameter';
 import { ErrorType } from '../utils/pseudoTypes';
-import { Type } from '../utils/baseType';
+import { Annotation, Type } from '../utils/baseType';
 import Literal from './Literal';
 import TypeLiteral from './TypeLiteral';
 import { resolveReferencedType } from '../utils/referenceTypes';
@@ -25,7 +25,7 @@ export default class MappedType extends Type {
   private type: Type = ErrType;
   private constraint: Type = ErrType;
   private questionToken: QuestionToken = QuestionToken.None;
-  public deriveLiteral() {
+  public deriveLiteral(parentAnnotations: Annotation[]) {
     /**
      * type X = {
      *  [typeParameter in constraint]: type
@@ -41,13 +41,13 @@ export default class MappedType extends Type {
     ) {
       const unionKeyTypes =
         constraint instanceof UnionType
-          ? constraint.derivePreservedUnionLiteral().getTypes()
+          ? constraint.derivePreservedUnionLiteral(parentAnnotations).getTypes()
           : [constraint];
 
       for (const keyType of unionKeyTypes) {
         let finalTypeForThisProperty: Type = ErrType;
         let originalQuestionMark = false;
-        let literalKeyType = keyType.deriveLiteral();
+        let literalKeyType = keyType.deriveLiteral(parentAnnotations);
         typeParameter.setActualType(literalKeyType);
         if (type instanceof IndexedAccessType) {
           const property = type.getProperty();
@@ -67,7 +67,7 @@ export default class MappedType extends Type {
           [],
         );
       }
-      return newTypeLiteral.deriveLiteral();
+      return newTypeLiteral.deriveLiteral(parentAnnotations);
     } else {
       throw Error(
         'Constraint other than UnionType and Literal in MappedType is not supported yet',

--- a/packages/@manta-style/runtime/src/types/OptionalType.ts
+++ b/packages/@manta-style/runtime/src/types/OptionalType.ts
@@ -6,7 +6,7 @@ export default class OptionalType extends Type {
     super();
     this.type = type;
   }
-  public deriveLiteral(annotations?: Annotation[]) {
+  public deriveLiteral(annotations: Annotation[]) {
     return this.type.deriveLiteral(annotations);
   }
 }

--- a/packages/@manta-style/runtime/src/types/ParenthesizedType.ts
+++ b/packages/@manta-style/runtime/src/types/ParenthesizedType.ts
@@ -1,7 +1,7 @@
 import { Type, Annotation } from '../utils/baseType';
 
 export default class ParenthesizedType extends Type {
-  private type: Type;
+  private readonly type: Type;
   constructor(type: Type) {
     super();
     this.type = type;
@@ -9,7 +9,7 @@ export default class ParenthesizedType extends Type {
   public getType() {
     return this.type;
   }
-  public deriveLiteral(annotations?: Annotation[]) {
+  public deriveLiteral(annotations: Annotation[]) {
     return this.type.deriveLiteral(annotations);
   }
 }

--- a/packages/@manta-style/runtime/src/types/TupleType.ts
+++ b/packages/@manta-style/runtime/src/types/TupleType.ts
@@ -1,23 +1,25 @@
-import { Type } from '../utils/baseType';
+import { Annotation, Type } from '../utils/baseType';
 import ArrayLiteral from './ArrayLiteral';
 import OptionalType from './OptionalType';
 import RestType from './RestType';
 
 export default class TupleType extends Type {
-  private elementTypes: Type[];
+  private readonly elementTypes: Type[];
   constructor(elementTypes: Type[]) {
     super();
     this.elementTypes = elementTypes;
   }
-  public deriveLiteral() {
+  public deriveLiteral(parentAnnotations: Annotation[]) {
     const arrayLiteral: Type[] = [];
     this.elementTypes.forEach((type) => {
       const chance = type instanceof OptionalType ? Math.random() : 1;
       if (chance > 0.5) {
         if (type instanceof RestType) {
-          arrayLiteral.push(...type.deriveLiteral().getElements());
+          arrayLiteral.push(
+            ...type.deriveLiteral(parentAnnotations).getElements(),
+          );
         } else {
-          arrayLiteral.push(type.deriveLiteral());
+          arrayLiteral.push(type.deriveLiteral(parentAnnotations));
         }
       }
     });

--- a/packages/@manta-style/runtime/src/types/TypeLiteral.ts
+++ b/packages/@manta-style/runtime/src/types/TypeLiteral.ts
@@ -11,6 +11,7 @@ import {
 import { resolveReferencedType } from '../utils/referenceTypes';
 import NeverKeyword from './NeverKeyword';
 import { intersection } from '../utils/intersection';
+import { inheritAnnotations } from '../utils/annotation';
 
 export default class TypeLiteral extends Type {
   private properties: Property[] = [];
@@ -51,13 +52,15 @@ export default class TypeLiteral extends Type {
       annotations,
     });
   }
-  public deriveLiteral() {
+  public deriveLiteral(parentAnnotations: Annotation[]) {
     const typeLiteral = new TypeLiteral();
 
     for (const property of this.properties) {
       typeLiteral.property(
         property.name,
-        property.type.deriveLiteral(property.annotations),
+        property.type.deriveLiteral(
+          inheritAnnotations(parentAnnotations, property.annotations),
+        ),
         property.questionMark,
         property.annotations,
       );
@@ -116,7 +119,7 @@ export default class TypeLiteral extends Type {
               ? actualType.getKeys()
               : actualType
                   .getTypes()
-                  .map((type) => type.deriveLiteral().mock());
+                  .map((type) => type.deriveLiteral([]).mock());
           for (const key of keys) {
             const chance = computedProperty.questionMark ? Math.random() : 1;
             if (chance > 0.5) {
@@ -158,9 +161,7 @@ export default class TypeLiteral extends Type {
         composedTypeLiteral.property(
           propS.name,
           intersection(propS.type, propT.type),
-          [propS.questionMark, propT.questionMark].every(Boolean)
-            ? true
-            : false,
+          [propS.questionMark, propT.questionMark].every(Boolean),
           [...propS.annotations, ...propT.annotations],
         );
       } else {

--- a/packages/@manta-style/runtime/src/types/TypeReference.ts
+++ b/packages/@manta-style/runtime/src/types/TypeReference.ts
@@ -1,22 +1,22 @@
 import MantaStyle from '../index';
-import { Type } from '../utils/baseType';
+import { Annotation, Type } from '../utils/baseType';
 import TypeAliasDeclaration from '../nodes/TypeAliasDeclaration';
 import { ReservedTypePrefix } from '@manta-style/consts';
 
 export default class TypeReference extends Type {
-  private referenceName: string;
+  private readonly referenceName: string;
   private referencedType?: TypeAliasDeclaration;
-  private deferredArgumentedTypes: Type[] = [];
+  private typeParameters: Type[] = [];
   constructor(referenceName: string) {
     super();
     this.referenceName = referenceName;
   }
-  public argumentTypes(types: Type[]) {
-    this.deferredArgumentedTypes = types;
+  public argumentTypes(actualTypes: Type[]) {
+    this.typeParameters = actualTypes;
     return this;
   }
-  public deriveLiteral() {
-    return this.getActualType().deriveLiteral();
+  public deriveLiteral(parentAnnotations: Annotation[]) {
+    return this.getActualType().deriveLiteral(parentAnnotations);
   }
   public getActualType() {
     if (
@@ -24,10 +24,10 @@ export default class TypeReference extends Type {
       this.referenceName.startsWith(ReservedTypePrefix.URLQuery)
     ) {
       this.referencedType = MantaStyle.referenceType(this.referenceName);
-      this.referencedType.argumentTypes(this.deferredArgumentedTypes);
+      this.referencedType.argumentTypes(this.typeParameters);
     } else {
       // Same as above line, but made TypeScript happy
-      this.referencedType.argumentTypes(this.deferredArgumentedTypes);
+      this.referencedType.argumentTypes(this.typeParameters);
     }
     return this.referencedType;
   }

--- a/packages/@manta-style/runtime/src/types/UnionType.ts
+++ b/packages/@manta-style/runtime/src/types/UnionType.ts
@@ -1,33 +1,35 @@
-import { Type } from '../utils/baseType';
+import { Annotation, Type } from '../utils/baseType';
 import { sample } from 'lodash-es';
 import NeverKeyword from './NeverKeyword';
 import { resolveReferencedType } from '../utils/referenceTypes';
 
 export default class UnionType extends Type {
-  private types: Type[] = [];
+  private readonly types: Type[] = [];
   private chosenType?: Type;
   constructor(types: Type[], chosenType?: Type) {
     super();
     this.types = types;
     this.chosenType = chosenType;
   }
-  public deriveLiteral() {
+  public deriveLiteral(parentAnnotations: Annotation[]) {
     const { chosenType } = this;
     if (chosenType) {
       return chosenType;
     } else {
-      const { chosenType } = this.derivePreservedUnionLiteral();
+      const { chosenType } = this.derivePreservedUnionLiteral(
+        parentAnnotations,
+      );
       if (chosenType) {
         return chosenType;
       }
       throw Error('Something bad happens :(');
     }
   }
-  public derivePreservedUnionLiteral() {
+  public derivePreservedUnionLiteral(parentAnnotations: Annotation[]) {
     const derivedTypes = this.types
       .map(resolveReferencedType)
       .filter((type) => !(type instanceof NeverKeyword))
-      .map((type) => type.deriveLiteral());
+      .map((type) => type.deriveLiteral(parentAnnotations));
     const chosenType = sample(derivedTypes);
     return new UnionType(derivedTypes, chosenType);
   }

--- a/packages/@manta-style/runtime/src/types/UnionType.ts
+++ b/packages/@manta-style/runtime/src/types/UnionType.ts
@@ -28,6 +28,7 @@ export default class UnionType extends Type {
   public derivePreservedUnionLiteral(parentAnnotations: Annotation[]) {
     const derivedTypes = this.types
       .map(resolveReferencedType)
+      .map((item) => item.type)
       .filter((type) => !(type instanceof NeverKeyword))
       .map((type) => type.deriveLiteral(parentAnnotations));
     const chosenType = sample(derivedTypes);

--- a/packages/@manta-style/runtime/src/utils/annotation.ts
+++ b/packages/@manta-style/runtime/src/utils/annotation.ts
@@ -37,3 +37,9 @@ export function getNumberFromAnnotationKey({
     }
   }
 }
+
+export function inheritAnnotations(parent: Annotation[], child: Annotation[]) {
+  const childKeys = child.map((item) => item.key);
+  const filteredParent = parent.filter((item) => !childKeys.includes(item.key));
+  return [...filteredParent, ...child];
+}

--- a/packages/@manta-style/runtime/src/utils/assignable.ts
+++ b/packages/@manta-style/runtime/src/utils/assignable.ts
@@ -10,8 +10,8 @@ import TypeLiteral from '../types/TypeLiteral';
 import IntersectionType from '../types/IntersectionType';
 
 export function isAssignable(typeS: Type, typeT: Type): boolean {
-  const S = resolveReferencedType(typeS);
-  const T = resolveReferencedType(typeT);
+  const { type: S } = resolveReferencedType(typeS);
+  const { type: T } = resolveReferencedType(typeT);
 
   if (Object.getPrototypeOf(S) === Object.getPrototypeOf(T)) {
     // - S and T are identical types.

--- a/packages/@manta-style/runtime/src/utils/baseType.ts
+++ b/packages/@manta-style/runtime/src/utils/baseType.ts
@@ -4,7 +4,7 @@ export type Annotation = {
 };
 
 export abstract class Type {
-  abstract deriveLiteral(annotations?: Annotation[]): Type;
+  abstract deriveLiteral(parentAnnotations: Annotation[]): Type;
   public mock(): any {
     throw new Error('Literal types should be derived before mock.');
   }

--- a/packages/@manta-style/runtime/src/utils/intersection.ts
+++ b/packages/@manta-style/runtime/src/utils/intersection.ts
@@ -3,8 +3,7 @@ import { isAssignable } from './assignable';
 import UnionType from '../types/UnionType';
 import TypeLiteral from '../types/TypeLiteral';
 import MantaStyle from '..';
-import { normalizeUnion } from '../utils/union';
-import NeverKeyword from '../types/NeverKeyword';
+import { normalizeUnion } from './union';
 
 export function intersection(S: Type, T: Type): Type {
   if (S instanceof UnionType) {

--- a/packages/@manta-style/runtime/src/utils/pseudoTypes.ts
+++ b/packages/@manta-style/runtime/src/utils/pseudoTypes.ts
@@ -1,7 +1,7 @@
 import { Type } from './baseType';
 
 export class ErrorType extends Type {
-  private message: string;
+  private readonly message: string;
   constructor(errorMessage: string) {
     super();
     this.message = errorMessage;

--- a/packages/@manta-style/runtime/src/utils/referenceTypes.ts
+++ b/packages/@manta-style/runtime/src/utils/referenceTypes.ts
@@ -29,10 +29,8 @@ export function resolveReferencedType(type: Type): Type {
       actualType = actualType.getActualType();
     } else if (actualType instanceof KeyOfKeyword) {
       actualType = actualType.deriveLiteral();
-    } else if (actualType instanceof ParenthesizedType) {
-      actualType = actualType.getType();
     } else {
-      throw new Error('Something bad happens :(');
+      actualType = actualType.getType();
     }
   }
   return actualType;

--- a/packages/@manta-style/runtime/src/utils/union.ts
+++ b/packages/@manta-style/runtime/src/utils/union.ts
@@ -9,6 +9,7 @@ export function normalizeUnion(unionType: UnionType): Type {
   const types = unionType
     .getTypes()
     .map(resolveReferencedType)
+    .map((item) => item.type)
     .filter((type) => !(type instanceof NeverKeyword));
   const { length } = types;
   if (length === 0) {

--- a/packages/@manta-style/runtime/src/utils/union.ts
+++ b/packages/@manta-style/runtime/src/utils/union.ts
@@ -2,7 +2,7 @@ import UnionType from '../types/UnionType';
 import { Type } from './baseType';
 import MantaStyle from '..';
 import NeverKeyword from '../types/NeverKeyword';
-import { resolveReferencedType } from '../utils/referenceTypes';
+import { resolveReferencedType } from './referenceTypes';
 
 export function normalizeUnion(unionType: UnionType): Type {
   // Filter out all 'never' keyword, since X | never = X

--- a/packages/@manta-style/typescript-builder/package.json
+++ b/packages/@manta-style/typescript-builder/package.json
@@ -28,7 +28,7 @@
     "@types/glob": "^5.0.35",
     "glob": "^7.1.2",
     "typescript": "^3.0.1",
-    "webpack": "^4.16.3",
+    "webpack": "^4.16.5",
     "webpack-cli": "^3.1.0"
   },
   "dependencies": {

--- a/packages/@manta-style/typescript-builder/src/index.ts
+++ b/packages/@manta-style/typescript-builder/src/index.ts
@@ -1,1 +1,2 @@
 export { default as build } from './utils/build';
+export { default as transpile } from './utils/transpile';

--- a/packages/@manta-style/typescript-builder/src/utils/transpile.ts
+++ b/packages/@manta-style/typescript-builder/src/utils/transpile.ts
@@ -1,0 +1,27 @@
+import * as ts from 'typescript';
+import { createTransformer } from '@manta-style/typescript-transformer';
+
+export default function transpile(
+  sourceCode: string,
+  importHelpers: boolean = true,
+): string {
+  const MantaStyleTranformer = createTransformer(importHelpers);
+  const sourceFile = ts.createSourceFile(
+    'test.ts',
+    sourceCode,
+    ts.ScriptTarget.ES5,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const result = ts.transform(sourceFile, [MantaStyleTranformer]);
+  const printer = ts.createPrinter({
+    newLine: ts.NewLineKind.LineFeed,
+  });
+  const transpiledResult = printer.printFile(result.transformed[0]);
+  const compileResult = ts.transpileModule(transpiledResult, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+    },
+  });
+  return compileResult.outputText;
+}

--- a/packages/@manta-style/typescript-helpers/package.json
+++ b/packages/@manta-style/typescript-helpers/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@manta-style/typescript-builder": "^0.0.15",
     "typescript": "3.0.1",
-    "webpack": "^4.16.3",
+    "webpack": "^4.16.5",
     "webpack-cli": "^3.1.0"
   }
 }

--- a/packages/@manta-style/typescript-transformer/package.json
+++ b/packages/@manta-style/typescript-transformer/package.json
@@ -23,14 +23,14 @@
     "build": "tsc -p tsconfig.json && webpack"
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0-beta.55",
+    "@babel/core": "^7.0.0-beta.56",
     "@manta-style/consts": "^0.0.0",
     "@types/jest": "^23.3.1",
     "jest": "^23.4.2",
     "source-map-loader": "^0.2.3",
-    "ts-jest": "^23.1.0",
+    "ts-jest": "^23.1.3",
     "typescript": "3.0.1",
-    "webpack": "^4.16.3",
+    "webpack": "^4.16.5",
     "webpack-cli": "^3.1.0"
   },
   "peerDependencies": {

--- a/packages/@manta-style/typescript-transformer/src/utils.ts
+++ b/packages/@manta-style/typescript-transformer/src/utils.ts
@@ -221,7 +221,7 @@ function createTypeLiteralProperties(
     const jsdocArray = ts.getJSDocTags(member);
     if (ts.isPropertySignature(member) && member.type) {
       statements.push(
-        ts.createStatement(
+        ts.createExpressionStatement(
           createRuntimeFunctionCall(
             'property',
             [
@@ -239,7 +239,7 @@ function createTypeLiteralProperties(
         const parameter = member.parameters[0];
         if (parameter.type) {
           statements.push(
-            ts.createStatement(
+            ts.createExpressionStatement(
               createRuntimeFunctionCall(
                 'computedProperty',
                 [
@@ -341,7 +341,7 @@ function createMappedType(
               referenceTypeParameters,
               'mappedType',
             ),
-            ts.createStatement(
+            ts.createExpressionStatement(
               createRuntimeFunctionCall(
                 'setQuestionToken',
                 [
@@ -358,7 +358,7 @@ function createMappedType(
                 'mappedType',
               ),
             ),
-            ts.createStatement(
+            ts.createExpressionStatement(
               createRuntimeFunctionCall(
                 'setConstraint',
                 [

--- a/packages/@manta-style/typescript-transformer/utils/transpiler.ts
+++ b/packages/@manta-style/typescript-transformer/utils/transpiler.ts
@@ -1,6 +1,5 @@
 import * as ts from 'typescript';
 import { createTransformer } from '../src';
-import * as vm from 'vm';
 
 const transformer = createTransformer(true);
 export function getTranspiledString(source: string): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,43 +108,43 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@lerna/add@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.0.0-rc.0.tgz#a2963cecda704b0030601c1db2aee3a579d3af74"
+"@lerna/add@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.0.0.tgz#90e660d55d18ee3f2dfd65aae5d07e0c71b29cdf"
   dependencies:
-    "@lerna/bootstrap" "^3.0.0-rc.0"
-    "@lerna/command" "^3.0.0-rc.0"
-    "@lerna/filter-options" "^3.0.0-rc.0"
-    "@lerna/validation-error" "^3.0.0-rc.0"
+    "@lerna/bootstrap" "^3.0.0"
+    "@lerna/command" "^3.0.0"
+    "@lerna/filter-options" "^3.0.0"
+    "@lerna/validation-error" "^3.0.0"
     dedent "^0.7.0"
     npm-package-arg "^6.0.0"
     p-map "^1.2.0"
     package-json "^4.0.1"
     semver "^5.5.0"
 
-"@lerna/batch-packages@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/batch-packages/-/batch-packages-3.0.0-rc.0.tgz#8e630a8042da8dd8cf5d3c61ab55f669d9a67d56"
+"@lerna/batch-packages@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/batch-packages/-/batch-packages-3.0.0.tgz#960a3dbb5fbc17283e2850448c76c023f6a35200"
   dependencies:
-    "@lerna/package-graph" "^3.0.0-rc.0"
-    "@lerna/validation-error" "^3.0.0-rc.0"
+    "@lerna/package-graph" "^3.0.0"
+    "@lerna/validation-error" "^3.0.0"
     npmlog "^4.1.2"
 
-"@lerna/bootstrap@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/bootstrap/-/bootstrap-3.0.0-rc.0.tgz#8a36f1ebfa17faf6d483fa5e8e73c2c22fbc608c"
+"@lerna/bootstrap@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/bootstrap/-/bootstrap-3.0.0.tgz#7dff0f27cadfea7f1381c886aa6b12da4011fdfd"
   dependencies:
-    "@lerna/batch-packages" "^3.0.0-rc.0"
-    "@lerna/command" "^3.0.0-rc.0"
-    "@lerna/filter-options" "^3.0.0-rc.0"
-    "@lerna/npm-conf" "^3.0.0-rc.0"
-    "@lerna/npm-install" "^3.0.0-rc.0"
-    "@lerna/rimraf-dir" "^3.0.0-rc.0"
-    "@lerna/run-lifecycle" "^3.0.0-rc.0"
-    "@lerna/run-parallel-batches" "^3.0.0-rc.0"
-    "@lerna/symlink-binary" "^3.0.0-rc.0"
-    "@lerna/symlink-dependencies" "^3.0.0-rc.0"
-    "@lerna/validation-error" "^3.0.0-rc.0"
+    "@lerna/batch-packages" "^3.0.0"
+    "@lerna/command" "^3.0.0"
+    "@lerna/filter-options" "^3.0.0"
+    "@lerna/npm-conf" "^3.0.0"
+    "@lerna/npm-install" "^3.0.0"
+    "@lerna/rimraf-dir" "^3.0.0"
+    "@lerna/run-lifecycle" "^3.0.0"
+    "@lerna/run-parallel-batches" "^3.0.0"
+    "@lerna/symlink-binary" "^3.0.0"
+    "@lerna/symlink-dependencies" "^3.0.0"
+    "@lerna/validation-error" "^3.0.0"
     dedent "^0.7.0"
     get-port "^3.2.0"
     multimatch "^2.1.0"
@@ -157,90 +157,90 @@
     read-package-tree "^5.1.6"
     semver "^5.5.0"
 
-"@lerna/changed@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.0.0-rc.0.tgz#7686a93dcd0630eac3b6114153dc8a301df6870c"
+"@lerna/changed@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.0.2.tgz#c90b8d1a00c93ce99b4f6dc34653c3b835d8d468"
   dependencies:
-    "@lerna/collect-updates" "^3.0.0-rc.0"
-    "@lerna/command" "^3.0.0-rc.0"
-    "@lerna/output" "^3.0.0-rc.0"
-    "@lerna/publish" "^3.0.0-rc.0"
-    chalk "^2.3.1"
+    "@lerna/collect-updates" "^3.0.0"
+    "@lerna/command" "^3.0.0"
+    "@lerna/listable" "^3.0.0"
+    "@lerna/output" "^3.0.0"
+    "@lerna/version" "^3.0.2"
 
-"@lerna/child-process@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/child-process/-/child-process-3.0.0-rc.0.tgz#52bede46bd244992bbea41c79893cefe5c90e17a"
+"@lerna/child-process@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/child-process/-/child-process-3.0.0.tgz#5b93ac65347eb5e317e9ce2524ab2bdd59f37cb7"
   dependencies:
     chalk "^2.3.1"
     execa "^0.10.0"
     strong-log-transformer "^1.0.6"
 
-"@lerna/clean@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/clean/-/clean-3.0.0-rc.0.tgz#bc65a7b4ec1b404e42d508b9c2a0c67d02665efc"
+"@lerna/clean@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/clean/-/clean-3.0.0.tgz#5e4dcf0fb376dda6fd5c717b4a6d1ceaff6284e9"
   dependencies:
-    "@lerna/command" "^3.0.0-rc.0"
-    "@lerna/filter-options" "^3.0.0-rc.0"
-    "@lerna/prompt" "^3.0.0-rc.0"
-    "@lerna/rimraf-dir" "^3.0.0-rc.0"
+    "@lerna/command" "^3.0.0"
+    "@lerna/filter-options" "^3.0.0"
+    "@lerna/prompt" "^3.0.0"
+    "@lerna/rimraf-dir" "^3.0.0"
     p-map "^1.2.0"
     p-map-series "^1.0.0"
     p-waterfall "^1.0.0"
 
-"@lerna/cli@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/cli/-/cli-3.0.0-rc.0.tgz#0934ca57f26570359cc8be9bda5ae80ba911e650"
+"@lerna/cli@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@lerna/cli/-/cli-3.0.3.tgz#b05055391b8b859493aa21b064479f3ad0b663e7"
   dependencies:
-    "@lerna/add" "^3.0.0-rc.0"
-    "@lerna/bootstrap" "^3.0.0-rc.0"
-    "@lerna/changed" "^3.0.0-rc.0"
-    "@lerna/clean" "^3.0.0-rc.0"
-    "@lerna/create" "^3.0.0-rc.0"
-    "@lerna/diff" "^3.0.0-rc.0"
-    "@lerna/exec" "^3.0.0-rc.0"
-    "@lerna/global-options" "^3.0.0-rc.0"
-    "@lerna/import" "^3.0.0-rc.0"
-    "@lerna/init" "^3.0.0-rc.0"
-    "@lerna/link" "^3.0.0-rc.0"
-    "@lerna/list" "^3.0.0-rc.0"
-    "@lerna/publish" "^3.0.0-rc.0"
-    "@lerna/run" "^3.0.0-rc.0"
+    "@lerna/add" "^3.0.0"
+    "@lerna/bootstrap" "^3.0.0"
+    "@lerna/changed" "^3.0.2"
+    "@lerna/clean" "^3.0.0"
+    "@lerna/create" "^3.0.0"
+    "@lerna/diff" "^3.0.0"
+    "@lerna/exec" "^3.0.2"
+    "@lerna/global-options" "^3.0.0"
+    "@lerna/import" "^3.0.0"
+    "@lerna/init" "^3.0.0"
+    "@lerna/link" "^3.0.0"
+    "@lerna/list" "^3.0.0"
+    "@lerna/publish" "^3.0.3"
+    "@lerna/run" "^3.0.2"
+    "@lerna/version" "^3.0.2"
     dedent "^0.7.0"
     is-ci "^1.0.10"
     npmlog "^4.1.2"
     yargs "^12.0.1"
 
-"@lerna/collect-updates@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/collect-updates/-/collect-updates-3.0.0-rc.0.tgz#f00f4b70750d21fa14100dcc83f665d8ee7c1e53"
+"@lerna/collect-updates@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/collect-updates/-/collect-updates-3.0.0.tgz#be4436e479adfc5540d9fb36e764d514ba9fb1c7"
   dependencies:
-    "@lerna/child-process" "^3.0.0-rc.0"
+    "@lerna/child-process" "^3.0.0"
     minimatch "^3.0.4"
     npmlog "^4.1.2"
-    semver "^5.5.0"
     slash "^1.0.0"
 
-"@lerna/command@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/command/-/command-3.0.0-rc.0.tgz#2bf6b25468f95d7c4a9e947f0c5cb1acd598eb44"
+"@lerna/command@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/command/-/command-3.0.0.tgz#c974029dac0486688dcf3e01351b982e45727aae"
   dependencies:
-    "@lerna/child-process" "^3.0.0-rc.0"
-    "@lerna/collect-updates" "^3.0.0-rc.0"
-    "@lerna/filter-packages" "^3.0.0-rc.0"
-    "@lerna/package-graph" "^3.0.0-rc.0"
-    "@lerna/project" "^3.0.0-rc.0"
-    "@lerna/validation-error" "^3.0.0-rc.0"
-    "@lerna/write-log-file" "^3.0.0-rc.0"
+    "@lerna/child-process" "^3.0.0"
+    "@lerna/collect-updates" "^3.0.0"
+    "@lerna/filter-packages" "^3.0.0"
+    "@lerna/package-graph" "^3.0.0"
+    "@lerna/project" "^3.0.0"
+    "@lerna/validation-error" "^3.0.0"
+    "@lerna/write-log-file" "^3.0.0"
     dedent "^0.7.0"
     execa "^0.10.0"
     lodash "^4.17.5"
     npmlog "^4.1.2"
 
-"@lerna/conventional-commits@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/conventional-commits/-/conventional-commits-3.0.0-rc.0.tgz#da5e1a0f6f6cc6bd7426a54274cccdfefa761d7c"
+"@lerna/conventional-commits@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@lerna/conventional-commits/-/conventional-commits-3.0.2.tgz#1089d06c4022bbea1d56e7e0b3801c9be9a62d71"
   dependencies:
-    "@lerna/validation-error" "^3.0.0-rc.0"
+    "@lerna/validation-error" "^3.0.0"
     conventional-changelog-angular "^1.6.6"
     conventional-changelog-core "^2.0.5"
     conventional-recommended-bump "^2.0.6"
@@ -251,22 +251,22 @@
     npmlog "^4.1.2"
     semver "^5.5.0"
 
-"@lerna/create-symlink@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/create-symlink/-/create-symlink-3.0.0-rc.0.tgz#88c998cb352194ecc0596fcab132e657f1ada02d"
+"@lerna/create-symlink@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/create-symlink/-/create-symlink-3.0.0.tgz#f7281028c011d0524f362531a36211724793f77f"
   dependencies:
     cmd-shim "^2.0.2"
     fs-extra "^6.0.1"
     npmlog "^4.1.2"
 
-"@lerna/create@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-3.0.0-rc.0.tgz#5607b7791d652f3754a9360199253605b8d3fd13"
+"@lerna/create@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-3.0.0.tgz#93945e4f71cf2c3fc13500bc91526d7a5c07a84c"
   dependencies:
-    "@lerna/child-process" "^3.0.0-rc.0"
-    "@lerna/command" "^3.0.0-rc.0"
-    "@lerna/npm-conf" "^3.0.0-rc.0"
-    "@lerna/validation-error" "^3.0.0-rc.0"
+    "@lerna/child-process" "^3.0.0"
+    "@lerna/command" "^3.0.0"
+    "@lerna/npm-conf" "^3.0.0"
+    "@lerna/validation-error" "^3.0.0"
     camelcase "^4.1.0"
     dedent "^0.7.0"
     fs-extra "^6.0.1"
@@ -279,161 +279,177 @@
     validate-npm-package-license "^3.0.3"
     validate-npm-package-name "^3.0.0"
 
-"@lerna/diff@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/diff/-/diff-3.0.0-rc.0.tgz#e52e54c104618ca60d3e55a314cf8312f6005df9"
+"@lerna/diff@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/diff/-/diff-3.0.0.tgz#7e7d175c5f6555d700b8b0592f154b11d2f7b646"
   dependencies:
-    "@lerna/child-process" "^3.0.0-rc.0"
-    "@lerna/command" "^3.0.0-rc.0"
-    "@lerna/validation-error" "^3.0.0-rc.0"
+    "@lerna/child-process" "^3.0.0"
+    "@lerna/command" "^3.0.0"
+    "@lerna/validation-error" "^3.0.0"
     npmlog "^4.1.2"
 
-"@lerna/exec@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/exec/-/exec-3.0.0-rc.0.tgz#5b42b876354e6643b792f7be66e71e8be25f0173"
+"@lerna/exec@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@lerna/exec/-/exec-3.0.2.tgz#97c055e5d636e4510362f0542f8b85ce9bc0a19b"
   dependencies:
-    "@lerna/batch-packages" "^3.0.0-rc.0"
-    "@lerna/child-process" "^3.0.0-rc.0"
-    "@lerna/command" "^3.0.0-rc.0"
-    "@lerna/filter-options" "^3.0.0-rc.0"
-    "@lerna/run-parallel-batches" "^3.0.0-rc.0"
-    "@lerna/validation-error" "^3.0.0-rc.0"
+    "@lerna/batch-packages" "^3.0.0"
+    "@lerna/child-process" "^3.0.0"
+    "@lerna/command" "^3.0.0"
+    "@lerna/filter-options" "^3.0.0"
+    "@lerna/run-parallel-batches" "^3.0.0"
+    "@lerna/validation-error" "^3.0.0"
 
-"@lerna/filter-options@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/filter-options/-/filter-options-3.0.0-rc.0.tgz#9e22b3326eece8f45adad878d44c905271967a59"
+"@lerna/filter-options@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/filter-options/-/filter-options-3.0.0.tgz#db329277f9c482b12993fa5c0ec4d145201ab399"
   dependencies:
     dedent "^0.7.0"
 
-"@lerna/filter-packages@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/filter-packages/-/filter-packages-3.0.0-rc.0.tgz#e78b48d000301d6750fff9a777988563d5cae0ed"
+"@lerna/filter-packages@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/filter-packages/-/filter-packages-3.0.0.tgz#5eb25ad1610f3e2ab845133d1f8d7d40314e838f"
   dependencies:
-    "@lerna/validation-error" "^3.0.0-rc.0"
+    "@lerna/validation-error" "^3.0.0"
     multimatch "^2.1.0"
     npmlog "^4.1.2"
 
-"@lerna/get-npm-exec-opts@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.0.0-rc.0.tgz#74cf4364fac1b3c8b6645259e892e34509c3b1d9"
+"@lerna/get-npm-exec-opts@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.0.0.tgz#8fc7866e8d8e9a2f2dc385287ba32eb44de8bdeb"
   dependencies:
     npmlog "^4.1.2"
 
-"@lerna/global-options@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/global-options/-/global-options-3.0.0-rc.0.tgz#1745cf71c473099f8e0fb12cf426dc6a2dd1f2c5"
+"@lerna/global-options@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/global-options/-/global-options-3.0.0.tgz#85d4878317816eba538b0d637e30dae89a2a9a92"
 
-"@lerna/import@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/import/-/import-3.0.0-rc.0.tgz#3b0b86ac89039d0a94b326013de8595d8d5ea214"
+"@lerna/import@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/import/-/import-3.0.0.tgz#2fd206c41aa9e4bab2fbb362aefa31c8a340f61e"
   dependencies:
-    "@lerna/child-process" "^3.0.0-rc.0"
-    "@lerna/command" "^3.0.0-rc.0"
-    "@lerna/prompt" "^3.0.0-rc.0"
-    "@lerna/validation-error" "^3.0.0-rc.0"
+    "@lerna/child-process" "^3.0.0"
+    "@lerna/command" "^3.0.0"
+    "@lerna/prompt" "^3.0.0"
+    "@lerna/validation-error" "^3.0.0"
     dedent "^0.7.0"
     fs-extra "^6.0.1"
     p-map-series "^1.0.0"
 
-"@lerna/init@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/init/-/init-3.0.0-rc.0.tgz#d75929096b3a2b09de2afa067cb9ea36f2a284cb"
+"@lerna/init@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/init/-/init-3.0.0.tgz#11d7726bc65b9dbf67668be3b218c1e19d7ac541"
   dependencies:
-    "@lerna/child-process" "^3.0.0-rc.0"
-    "@lerna/command" "^3.0.0-rc.0"
+    "@lerna/child-process" "^3.0.0"
+    "@lerna/command" "^3.0.0"
     fs-extra "^6.0.1"
     p-map "^1.2.0"
     write-json-file "^2.3.0"
 
-"@lerna/link@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/link/-/link-3.0.0-rc.0.tgz#87e7c59914ee205d79383d967e694e0acfaebb73"
+"@lerna/link@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/link/-/link-3.0.0.tgz#874d57b104f1609e0e5887f795896c6983a2e229"
   dependencies:
-    "@lerna/command" "^3.0.0-rc.0"
-    "@lerna/package-graph" "^3.0.0-rc.0"
-    "@lerna/symlink-dependencies" "^3.0.0-rc.0"
+    "@lerna/command" "^3.0.0"
+    "@lerna/package-graph" "^3.0.0"
+    "@lerna/symlink-dependencies" "^3.0.0"
     p-map "^1.2.0"
     slash "^1.0.0"
 
-"@lerna/list@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/list/-/list-3.0.0-rc.0.tgz#14acc6839f8fe1e1a0f3c20e9b2312160bda5b85"
+"@lerna/list@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/list/-/list-3.0.0.tgz#509bfe9853f18742f5375b8cc693ea843d27405a"
   dependencies:
-    "@lerna/command" "^3.0.0-rc.0"
-    "@lerna/filter-options" "^3.0.0-rc.0"
-    "@lerna/output" "^3.0.0-rc.0"
+    "@lerna/command" "^3.0.0"
+    "@lerna/filter-options" "^3.0.0"
+    "@lerna/listable" "^3.0.0"
+    "@lerna/output" "^3.0.0"
+
+"@lerna/listable@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/listable/-/listable-3.0.0.tgz#27209b1382c87abdbc964220e75c247d803d4199"
+  dependencies:
     chalk "^2.3.1"
     columnify "^1.5.4"
 
-"@lerna/npm-conf@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-conf/-/npm-conf-3.0.0-rc.0.tgz#8b38a3ce8280c9f5cd2958ef7a14861f2e540060"
+"@lerna/log-packed@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/log-packed/-/log-packed-3.0.0.tgz#d264ee611c64f0995153751f5c3d95defed71807"
+  dependencies:
+    byte-size "^4.0.3"
+    columnify "^1.5.4"
+    has-unicode "^2.0.1"
+    npmlog "^4.1.2"
+
+"@lerna/npm-conf@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-conf/-/npm-conf-3.0.0.tgz#7a4b8304a0ecd1e366208f656bd3d7f4dcb3b5e7"
   dependencies:
     config-chain "^1.1.11"
     pify "^3.0.0"
 
-"@lerna/npm-dist-tag@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-dist-tag/-/npm-dist-tag-3.0.0-rc.0.tgz#77efdc087f44de5853cbe47cebf0307b47d4fd99"
+"@lerna/npm-dist-tag@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-dist-tag/-/npm-dist-tag-3.0.0.tgz#73d9c37e4032c981bdfcea2fefef5eedd63966ec"
   dependencies:
-    "@lerna/child-process" "^3.0.0-rc.0"
-    "@lerna/get-npm-exec-opts" "^3.0.0-rc.0"
+    "@lerna/child-process" "^3.0.0"
+    "@lerna/get-npm-exec-opts" "^3.0.0"
     npmlog "^4.1.2"
 
-"@lerna/npm-install@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-install/-/npm-install-3.0.0-rc.0.tgz#0a338f7b4dbed4b504f1fabe66c1c008d1e5ed98"
+"@lerna/npm-install@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-install/-/npm-install-3.0.0.tgz#189c0481721e0c36c622b3c415915cb43cb41eb4"
   dependencies:
-    "@lerna/child-process" "^3.0.0-rc.0"
-    "@lerna/get-npm-exec-opts" "^3.0.0-rc.0"
+    "@lerna/child-process" "^3.0.0"
+    "@lerna/get-npm-exec-opts" "^3.0.0"
     fs-extra "^6.0.1"
     npm-package-arg "^6.0.0"
     npmlog "^4.1.2"
     signal-exit "^3.0.2"
     write-pkg "^3.1.0"
 
-"@lerna/npm-publish@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-publish/-/npm-publish-3.0.0-rc.0.tgz#9c3058ca5a35e239f4219a84b0ae76b1589f7de3"
+"@lerna/npm-publish@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-publish/-/npm-publish-3.0.0.tgz#4d0a87a9e8b207f1f6ad30ce6cfb3bc86e084e65"
   dependencies:
-    "@lerna/child-process" "^3.0.0-rc.0"
-    "@lerna/get-npm-exec-opts" "^3.0.0-rc.0"
+    "@lerna/child-process" "^3.0.0"
+    "@lerna/get-npm-exec-opts" "^3.0.0"
+    "@lerna/log-packed" "^3.0.0"
     npmlog "^4.1.2"
 
-"@lerna/npm-run-script@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-run-script/-/npm-run-script-3.0.0-rc.0.tgz#3f9906a80908529cda1832522834fce1cb165303"
+"@lerna/npm-run-script@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-run-script/-/npm-run-script-3.0.0.tgz#771be1f9bd96f1ab35870334d2011dff0b0e7997"
   dependencies:
-    "@lerna/child-process" "^3.0.0-rc.0"
-    "@lerna/get-npm-exec-opts" "^3.0.0-rc.0"
+    "@lerna/child-process" "^3.0.0"
+    "@lerna/get-npm-exec-opts" "^3.0.0"
     npmlog "^4.1.2"
 
-"@lerna/output@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/output/-/output-3.0.0-rc.0.tgz#5d7f4278842d79be0636a1863e23ba478116c0c9"
+"@lerna/output@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/output/-/output-3.0.0.tgz#4ed4a30ed2f311046b714b3840a090990ba3ce35"
   dependencies:
     npmlog "^4.1.2"
 
-"@lerna/package-graph@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/package-graph/-/package-graph-3.0.0-rc.0.tgz#0a63ec93e4613ee58f753fcb53b2f4c6cb678d8d"
+"@lerna/package-graph@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/package-graph/-/package-graph-3.0.0.tgz#f2e9131856c4f43ea91f2cab1bfe5c9264079f53"
   dependencies:
     npm-package-arg "^6.0.0"
     semver "^5.5.0"
 
-"@lerna/package@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/package/-/package-3.0.0-rc.0.tgz#40dd1939d8a644b6ab4afa297d35ef52b1997d4e"
+"@lerna/package@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/package/-/package-3.0.0.tgz#14afc9a6cb1f7f7b23c1d7c7aa81bdac7d44c0e5"
   dependencies:
     npm-package-arg "^6.0.0"
     write-pkg "^3.1.0"
 
-"@lerna/project@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/project/-/project-3.0.0-rc.0.tgz#82c9194e602e35b5574d6d238da33a537fe8b160"
+"@lerna/project@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/project/-/project-3.0.0.tgz#4320d2a2b4080cabcf95161d9c48475217d8a545"
   dependencies:
-    "@lerna/package" "^3.0.0-rc.0"
-    "@lerna/validation-error" "^3.0.0-rc.0"
+    "@lerna/package" "^3.0.0"
+    "@lerna/validation-error" "^3.0.0"
     cosmiconfig "^5.0.2"
     dedent "^0.7.0"
     dot-prop "^4.2.0"
@@ -445,119 +461,136 @@
     resolve-from "^4.0.0"
     write-json-file "^2.3.0"
 
-"@lerna/prompt@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/prompt/-/prompt-3.0.0-rc.0.tgz#5d9a4c192f10f3a0050869c5cfefc7671229b3fd"
+"@lerna/prompt@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/prompt/-/prompt-3.0.0.tgz#8e506de608d16d78d39f5dde59e81b4f8ecf720e"
   dependencies:
     inquirer "^5.1.0"
     npmlog "^4.1.2"
 
-"@lerna/publish@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.0.0-rc.0.tgz#ddbd7170c9169f84517f5e0c839acfddad4c2714"
+"@lerna/publish@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.0.3.tgz#4b3f621aa880743d70e1a0055eb46f5e9f03ad4a"
   dependencies:
-    "@lerna/batch-packages" "^3.0.0-rc.0"
-    "@lerna/child-process" "^3.0.0-rc.0"
-    "@lerna/collect-updates" "^3.0.0-rc.0"
-    "@lerna/command" "^3.0.0-rc.0"
-    "@lerna/conventional-commits" "^3.0.0-rc.0"
-    "@lerna/npm-dist-tag" "^3.0.0-rc.0"
-    "@lerna/npm-publish" "^3.0.0-rc.0"
-    "@lerna/output" "^3.0.0-rc.0"
-    "@lerna/prompt" "^3.0.0-rc.0"
-    "@lerna/run-lifecycle" "^3.0.0-rc.0"
-    "@lerna/run-parallel-batches" "^3.0.0-rc.0"
-    "@lerna/validation-error" "^3.0.0-rc.0"
-    chalk "^2.3.1"
-    dedent "^0.7.0"
+    "@lerna/batch-packages" "^3.0.0"
+    "@lerna/child-process" "^3.0.0"
+    "@lerna/collect-updates" "^3.0.0"
+    "@lerna/command" "^3.0.0"
+    "@lerna/get-npm-exec-opts" "^3.0.0"
+    "@lerna/npm-dist-tag" "^3.0.0"
+    "@lerna/npm-publish" "^3.0.0"
+    "@lerna/output" "^3.0.0"
+    "@lerna/run-lifecycle" "^3.0.0"
+    "@lerna/run-parallel-batches" "^3.0.0"
+    "@lerna/validation-error" "^3.0.0"
+    "@lerna/version" "^3.0.2"
     fs-extra "^6.0.1"
-    minimatch "^3.0.4"
+    npm-package-arg "^6.0.0"
     npmlog "^4.1.2"
     p-finally "^1.0.0"
+    p-map "^1.2.0"
+    p-reduce "^1.0.0"
+    semver "^5.5.0"
+
+"@lerna/resolve-symlink@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/resolve-symlink/-/resolve-symlink-3.0.0.tgz#40e2c59faa9298cd2003eeb8433b6a3b28f57c84"
+  dependencies:
+    fs-extra "^6.0.1"
+    npmlog "^4.1.2"
+    read-cmd-shim "^1.0.1"
+
+"@lerna/rimraf-dir@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/rimraf-dir/-/rimraf-dir-3.0.0.tgz#6d3a4872e79f86c152630454ecd27f211125bad0"
+  dependencies:
+    "@lerna/child-process" "^3.0.0"
+    npmlog "^4.1.2"
+    path-exists "^3.0.0"
+    rimraf "^2.6.2"
+
+"@lerna/run-lifecycle@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/run-lifecycle/-/run-lifecycle-3.0.0.tgz#3d9a09b390f53dd321ae4be8c7b779714d4037fe"
+  dependencies:
+    "@lerna/npm-conf" "^3.0.0"
+    npm-lifecycle "^2.0.0"
+    npmlog "^4.1.2"
+
+"@lerna/run-parallel-batches@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/run-parallel-batches/-/run-parallel-batches-3.0.0.tgz#468704934084c74991d3124d80607857d4dfa840"
+  dependencies:
+    p-map "^1.2.0"
+    p-map-series "^1.0.0"
+
+"@lerna/run@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@lerna/run/-/run-3.0.2.tgz#ebda5894cf6c5b78442d510c6d6d86579945e8fb"
+  dependencies:
+    "@lerna/batch-packages" "^3.0.0"
+    "@lerna/command" "^3.0.0"
+    "@lerna/filter-options" "^3.0.0"
+    "@lerna/npm-run-script" "^3.0.0"
+    "@lerna/output" "^3.0.0"
+    "@lerna/run-parallel-batches" "^3.0.0"
+    "@lerna/validation-error" "^3.0.0"
+    p-map "^1.2.0"
+
+"@lerna/symlink-binary@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/symlink-binary/-/symlink-binary-3.0.0.tgz#f4ea3817c0a38316eddc8a7a75311e8b85731240"
+  dependencies:
+    "@lerna/create-symlink" "^3.0.0"
+    "@lerna/package" "^3.0.0"
+    fs-extra "^6.0.1"
+    p-map "^1.2.0"
+    read-pkg "^3.0.0"
+
+"@lerna/symlink-dependencies@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/symlink-dependencies/-/symlink-dependencies-3.0.0.tgz#649f4dc9225dfb047bd49fa4204b4859a7008db2"
+  dependencies:
+    "@lerna/create-symlink" "^3.0.0"
+    "@lerna/resolve-symlink" "^3.0.0"
+    "@lerna/symlink-binary" "^3.0.0"
+    fs-extra "^6.0.1"
+    p-finally "^1.0.0"
+    p-map "^1.2.0"
+    p-map-series "^1.0.0"
+
+"@lerna/validation-error@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/validation-error/-/validation-error-3.0.0.tgz#a27e90051c3ba71995e2a800a43d94ad04b3e3f4"
+  dependencies:
+    npmlog "^4.1.2"
+
+"@lerna/version@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@lerna/version/-/version-3.0.2.tgz#befa2a09be44af56668ef34785269187fe08f7bb"
+  dependencies:
+    "@lerna/child-process" "^3.0.0"
+    "@lerna/collect-updates" "^3.0.0"
+    "@lerna/command" "^3.0.0"
+    "@lerna/conventional-commits" "^3.0.2"
+    "@lerna/output" "^3.0.0"
+    "@lerna/prompt" "^3.0.0"
+    "@lerna/run-lifecycle" "^3.0.0"
+    "@lerna/validation-error" "^3.0.0"
+    chalk "^2.3.1"
+    dedent "^0.7.0"
+    minimatch "^3.0.4"
+    npmlog "^4.1.2"
     p-map "^1.2.0"
     p-reduce "^1.0.0"
     p-waterfall "^1.0.0"
     semver "^5.5.0"
     slash "^1.0.0"
     temp-write "^3.4.0"
-    write-json-file "^2.3.0"
 
-"@lerna/resolve-symlink@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/resolve-symlink/-/resolve-symlink-3.0.0-rc.0.tgz#fe7c8663e36761e51ffb6977de142fa6ea960bdd"
-  dependencies:
-    fs-extra "^6.0.1"
-    npmlog "^4.1.2"
-    read-cmd-shim "^1.0.1"
-
-"@lerna/rimraf-dir@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/rimraf-dir/-/rimraf-dir-3.0.0-rc.0.tgz#9942a5fbb084dea251ac9fda98ea242b7672126b"
-  dependencies:
-    "@lerna/child-process" "^3.0.0-rc.0"
-    npmlog "^4.1.2"
-    path-exists "^3.0.0"
-    rimraf "^2.6.2"
-
-"@lerna/run-lifecycle@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/run-lifecycle/-/run-lifecycle-3.0.0-rc.0.tgz#50787d9d8726723fe625f7b6418f41f446c86b21"
-  dependencies:
-    "@lerna/npm-conf" "^3.0.0-rc.0"
-    npm-lifecycle "^2.0.0"
-    npmlog "^4.1.2"
-
-"@lerna/run-parallel-batches@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/run-parallel-batches/-/run-parallel-batches-3.0.0-rc.0.tgz#80265e1fe6cad8d321297c7445b0e6f57984fa3e"
-  dependencies:
-    p-map "^1.2.0"
-    p-map-series "^1.0.0"
-
-"@lerna/run@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/run/-/run-3.0.0-rc.0.tgz#f2ae27dcc35eb32854ffe89764d425ecc013961b"
-  dependencies:
-    "@lerna/batch-packages" "^3.0.0-rc.0"
-    "@lerna/command" "^3.0.0-rc.0"
-    "@lerna/filter-options" "^3.0.0-rc.0"
-    "@lerna/npm-run-script" "^3.0.0-rc.0"
-    "@lerna/output" "^3.0.0-rc.0"
-    "@lerna/run-parallel-batches" "^3.0.0-rc.0"
-    "@lerna/validation-error" "^3.0.0-rc.0"
-    p-map "^1.2.0"
-
-"@lerna/symlink-binary@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/symlink-binary/-/symlink-binary-3.0.0-rc.0.tgz#0b3a6723fb857942baec6118ecee35ee0c6d082e"
-  dependencies:
-    "@lerna/create-symlink" "^3.0.0-rc.0"
-    "@lerna/package" "^3.0.0-rc.0"
-    fs-extra "^6.0.1"
-    p-map "^1.2.0"
-    read-pkg "^3.0.0"
-
-"@lerna/symlink-dependencies@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/symlink-dependencies/-/symlink-dependencies-3.0.0-rc.0.tgz#bbd73ca0835bbb005e5ee8df875d8f6f80ee6038"
-  dependencies:
-    "@lerna/create-symlink" "^3.0.0-rc.0"
-    "@lerna/resolve-symlink" "^3.0.0-rc.0"
-    "@lerna/symlink-binary" "^3.0.0-rc.0"
-    fs-extra "^6.0.1"
-    p-finally "^1.0.0"
-    p-map "^1.2.0"
-    p-map-series "^1.0.0"
-
-"@lerna/validation-error@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/validation-error/-/validation-error-3.0.0-rc.0.tgz#da81862666992b6befab25a4c855440679005e46"
-  dependencies:
-    npmlog "^4.1.2"
-
-"@lerna/write-log-file@^3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@lerna/write-log-file/-/write-log-file-3.0.0-rc.0.tgz#c506b0024f77ee8333c5b825b4bfae2243c471ab"
+"@lerna/write-log-file@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lerna/write-log-file/-/write-log-file-3.0.0.tgz#2f95fee80c6821fe1ee6ccf8173d2b4079debbd2"
   dependencies:
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
@@ -1498,6 +1531,10 @@ builtins@^1.0.3:
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
+
+byte-size@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-4.0.3.tgz#b7c095efc68eadf82985fccd9a2df43a74fa2ccd"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -3006,7 +3043,7 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
-has-unicode@^2.0.0:
+has-unicode@^2.0.0, has-unicode@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
@@ -4025,11 +4062,11 @@ left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
 
-lerna@^3.0.0-beta.21:
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.0.0-rc.0.tgz#ce7aa6a13151d75e36fe92cf6c9dd27821acae30"
+lerna@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.0.3.tgz#130b98e51ac4d2889fad7a753f934ddd4440072f"
   dependencies:
-    "@lerna/cli" "^3.0.0-rc.0"
+    "@lerna/cli" "^3.0.3"
     import-local "^1.0.0"
     npmlog "^4.1.2"
 
@@ -5008,9 +5045,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.13.7:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.0.tgz#847c235522035fd988100f1f43cf20a7d24f9372"
+prettier@^1.14.2:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
 
 pretty-format@^23.2.0:
   version "23.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,23 +2,23 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.0.0-beta.55", "@babel/code-frame@^7.0.0-beta.35":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.55.tgz#71f530e7b010af5eb7a7df7752f78921dd57e9ee"
+"@babel/code-frame@7.0.0-beta.56", "@babel/code-frame@^7.0.0-beta.35":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz#09f76300673ac085d3b90e02aafa0ffc2c96846a"
   dependencies:
-    "@babel/highlight" "7.0.0-beta.55"
+    "@babel/highlight" "7.0.0-beta.56"
 
-"@babel/core@^7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0-beta.55.tgz#9e17c34b5ac855e427c98f570915a17fcc6bab4a"
+"@babel/core@^7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0-beta.56.tgz#cc03ffbb62564fef58fd1cefcbb3e32011c21df9"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.55"
-    "@babel/generator" "7.0.0-beta.55"
-    "@babel/helpers" "7.0.0-beta.55"
-    "@babel/parser" "7.0.0-beta.55"
-    "@babel/template" "7.0.0-beta.55"
-    "@babel/traverse" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/code-frame" "7.0.0-beta.56"
+    "@babel/generator" "7.0.0-beta.56"
+    "@babel/helpers" "7.0.0-beta.56"
+    "@babel/parser" "7.0.0-beta.56"
+    "@babel/template" "7.0.0-beta.56"
+    "@babel/traverse" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
     convert-source-map "^1.1.0"
     debug "^3.1.0"
     json5 "^0.5.0"
@@ -27,82 +27,82 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.55.tgz#8ec11152dcc398bae35dd181122704415c383a01"
+"@babel/generator@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.56.tgz#07d9c2f45990c453130e080eddcd252a9cbd8d66"
   dependencies:
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/types" "7.0.0-beta.56"
     jsesc "^2.5.1"
     lodash "^4.17.10"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/helper-function-name@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.55.tgz#16aab21380a2eabcee3328d21b9586ba3427dbef"
+"@babel/helper-function-name@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz#4e9c8a84ce4368b4a779409d0c4fe3f714be60ab"
   dependencies:
-    "@babel/helper-get-function-arity" "7.0.0-beta.55"
-    "@babel/template" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/helper-get-function-arity" "7.0.0-beta.56"
+    "@babel/template" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/helper-get-function-arity@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.55.tgz#8559ded96ecd3b626f9c1f57494edc4fa3cc6a94"
+"@babel/helper-get-function-arity@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz#872864d67e25705b94d1c71afc72344aafc8dc9c"
   dependencies:
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/helper-split-export-declaration@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.55.tgz#ecb8074bf2d22c6518a252282535def137a8704f"
+"@babel/helper-split-export-declaration@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz#82d53382836134ba3ed0ea2394ca21fe579ec241"
   dependencies:
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/helpers@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.0.0-beta.55.tgz#d0b4b9a327dba42d58890011deb905c820739617"
+"@babel/helpers@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.0.0-beta.56.tgz#a01cac1481c6fa38197ae410137539045b160443"
   dependencies:
-    "@babel/template" "7.0.0-beta.55"
-    "@babel/traverse" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/template" "7.0.0-beta.56"
+    "@babel/traverse" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/highlight@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.55.tgz#988653647d629c261dae156e74d5f0252ba520c0"
+"@babel/highlight@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.56.tgz#f8b0fc8c5c2de53bb2c12f9001ad3d99e573696d"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/parser@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.55.tgz#0a527efc148c6c8cd85d5ffddacad817a2daeeb2"
+"@babel/parser@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.56.tgz#8638aa02e0130cd10b2ba4128e2b804112073ed3"
 
-"@babel/template@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.55.tgz#c6cab0e2722ba5e33fe034073b6d31673aba326e"
+"@babel/template@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.56.tgz#a428197e0c9db142f8581cbfdcfa9289b0dd7fd7"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.55"
-    "@babel/parser" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/code-frame" "7.0.0-beta.56"
+    "@babel/parser" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
     lodash "^4.17.10"
 
-"@babel/traverse@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.55.tgz#50be5d0fcc5cc4ac020a7b0c519be8dae345d4be"
+"@babel/traverse@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.56.tgz#62fdfe69328cfaad414ef01844f5ab40e32f4ad0"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.55"
-    "@babel/generator" "7.0.0-beta.55"
-    "@babel/helper-function-name" "7.0.0-beta.55"
-    "@babel/helper-split-export-declaration" "7.0.0-beta.55"
-    "@babel/parser" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/code-frame" "7.0.0-beta.56"
+    "@babel/generator" "7.0.0-beta.56"
+    "@babel/helper-function-name" "7.0.0-beta.56"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.56"
+    "@babel/parser" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
     debug "^3.1.0"
     globals "^11.1.0"
     lodash "^4.17.10"
 
-"@babel/types@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.55.tgz#7755c9d2e58315a64f05d8cf3322379be16d9199"
+"@babel/types@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.56.tgz#df456947a82510ec30361971e566110d89489056"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
@@ -703,8 +703,8 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
 
 "@types/node@*":
-  version "10.5.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.5.tgz#8e84d24e896cd77b0d4f73df274027e3149ec2ba"
+  version "10.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.7.tgz#960d9feb3ade2233bcc9843c918d740b4f78a7cf"
 
 "@types/query-string@^6.1.0":
   version "6.1.0"
@@ -1131,8 +1131,8 @@ aws-sign2@~0.7.0:
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
 
 aws4@^1.2.1, aws4@^1.6.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -1764,9 +1764,9 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.16.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
+commander@^2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
 commander@~2.13.0:
   version "2.13.0"
@@ -3237,8 +3237,8 @@ inquirer@^5.1.0:
     through "^2.3.6"
 
 inquirer@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.0.0.tgz#e8c20303ddc15bbfc2c12a6213710ccd9e1413d8"
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.1.0.tgz#8f65c7b31c498285f4ddf3b742ad8c487892040b"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.0"
@@ -4925,8 +4925,8 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -5036,8 +5036,8 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
 
 prompts@^0.1.9:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.13.tgz#7fad7ee1c6cafe49834ca0b2a6a471262de57620"
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"
   dependencies:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
@@ -5068,8 +5068,8 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 psl@^1.1.24:
-  version "1.1.28"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.28.tgz#4fb6ceb08a1e2214d4fd4de0ca22dae13740bc7b"
+  version "1.1.29"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
 
 public-encrypt@^4.0.0:
   version "4.0.2"
@@ -5545,8 +5545,8 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
 schema-utils@^0.4.4, schema-utils@^0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.5.tgz#21836f0608aac17b78f9e3e24daff14a5ca13a3e"
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
   dependencies:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
@@ -6140,9 +6140,9 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-ts-jest@^23.1.0:
-  version "23.1.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.1.0.tgz#1d193a3b51d78793062f1f9137629f8921301aa1"
+ts-jest@^23.1.3:
+  version "23.1.3"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.1.3.tgz#33e3187d3ef0d42adada6347acf2c3539ac56107"
   dependencies:
     closest-file-data "^0.1.4"
     fs-extra "6.0.1"
@@ -6335,12 +6335,12 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 v8-compile-cache@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.0.tgz#526492e35fc616864284700b7043e01baee09f0a"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz#a428b28bb26790734c4fc8bc9fa106fccebf6a6c"
 
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
@@ -6429,9 +6429,9 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.16.3:
-  version "4.16.4"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.16.4.tgz#6b020f76483bc66339164c296d89978aa100d37a"
+webpack@^4.16.5:
+  version "4.16.5"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.16.5.tgz#29fb39462823d7eb8aefcab8b45f7f241db0d092"
   dependencies:
     "@webassemblyjs/ast" "1.5.13"
     "@webassemblyjs/helper-module-context" "1.5.13"


### PR DESCRIPTION
```typescript
/**
 * @length 5
 */
type AType = BType[];
```

Now `@length 5` can pass down to the array type.