### PR TITLE
ms compiler -- for dev

### DIFF
--- a/packages/@manta-style/cli/package.json
+++ b/packages/@manta-style/cli/package.json
@@ -16,7 +16,8 @@
     "access": "public"
   },
   "bin": {
-    "ms": "./lib/index.js"
+    "ms": "./lib/index.js",
+    "msc": "./lib/compile.js"
   },
   "scripts": {
     "test": "echo 'No test yet'",

--- a/packages/@manta-style/cli/src/compile.ts
+++ b/packages/@manta-style/cli/src/compile.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import * as path from 'path';
+import * as builder from '@manta-style/typescript-builder';
+import * as program from 'commander';
+import findRoot = require('find-root');
+import chalk from 'chalk';
+
+program
+  .version('0.0.11')
+  .option(
+    '-c --configFile <file>',
+    'the TypeScript config file to generate entry points',
+  )
+  .option('-v --verbose', 'show debug information')
+  .parse(process.argv);
+
+const { configFile, verbose = false } = program;
+
+if (!configFile) {
+  console.log(
+    'Please specifiy a entry point config file by using --configFile.',
+  );
+  process.exit(1);
+}
+
+const tmpDir = findRoot(process.cwd()) + '/.mantastyle-tmp';
+builder.build(path.resolve(configFile), tmpDir, verbose);
+console.log(
+  chalk.green(
+    `Built manta-style runnable code into ${chalk.underline.white(tmpDir)}`,
+  ),
+);


### PR DESCRIPTION
create a command called `msc` for building manta code.
don't have to spin up the express server while developing manta-style, when you need only the compiler.