### PR TITLE
Validation Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:10.8
+      - image: circleci/node:10.13
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,5 +40,8 @@ jobs:
       - run: yarn build
 
       # run tests!
-      - run: yarn test
+      - run:
+          name: Test Cases
+          command: 'yarn test'
+          no_output_timeout: 60m
       - run: greenkeeper-lockfile-upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,5 +43,5 @@ jobs:
       - run:
           name: Test Cases
           command: 'yarn test'
-          no_output_timeout: 60m
+          no_output_timeout: 15m
       - run: greenkeeper-lockfile-upload

--- a/packages/builders/builder-flowtype/src/index.ts
+++ b/packages/builders/builder-flowtype/src/index.ts
@@ -5,7 +5,7 @@ import transpile from './utils/transpile';
 const typescriptBuilderPlugin: BuilderPlugin = {
   name: 'FlowType Builder',
   supportedExtensions: ['js'],
-  async buildConfigFile(configFilePath, destDir, verbose, importHelpers) {
+  async buildConfigFile({ configFilePath, destDir, verbose, importHelpers }) {
     const compiledFilePath = build(
       configFilePath,
       destDir,

--- a/packages/builders/builder-flowtype/src/index.ts
+++ b/packages/builders/builder-flowtype/src/index.ts
@@ -5,10 +5,17 @@ import transpile from './utils/transpile';
 const typescriptBuilderPlugin: BuilderPlugin = {
   name: 'FlowType Builder',
   supportedExtensions: ['js'],
-  async buildConfigFile({ configFilePath, destDir, verbose, importHelpers }) {
+  async buildConfigFile({
+    configFilePath,
+    destDir,
+    verbose,
+    importHelpers,
+    transpileModule,
+  }) {
     const compiledFilePath = build(
       configFilePath,
       destDir,
+      transpileModule,
       verbose,
       importHelpers,
     );

--- a/packages/builders/builder-flowtype/src/utils/build.ts
+++ b/packages/builders/builder-flowtype/src/utils/build.ts
@@ -5,11 +5,14 @@ import { createTransformer } from '../transformer';
 export default async function build(
   fileName: string,
   destDir: string,
+  transpileModule: boolean,
   verbose: boolean = false,
   importHelpers: boolean = true,
 ) {
   const sourceCode = await fs.readFile(fileName, 'utf-8');
-  const compiledContent = createTransformer(importHelpers)(sourceCode);
+  const compiledContent = createTransformer(importHelpers, transpileModule)(
+    sourceCode,
+  );
   console.log(destDir, fileName);
   const destPath = path.join(destDir, path.basename(fileName));
   await fs.writeFile(destPath, compiledContent, 'utf-8');

--- a/packages/builders/builder-flowtype/src/utils/transpile.ts
+++ b/packages/builders/builder-flowtype/src/utils/transpile.ts
@@ -4,5 +4,5 @@ export default function transpile(
   sourceCode: string,
   importHelpers: boolean = true,
 ): string {
-  return createTransformer(importHelpers)(sourceCode);
+  return createTransformer(importHelpers, true)(sourceCode);
 }

--- a/packages/builders/builder-typescript/package.json
+++ b/packages/builders/builder-typescript/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0-alpha.7",
   "description": "TypeScript Language Support",
   "main": "./lib/typescript-builder.js",
-  "typings": "./lib/index.d.js",
+  "typings": "./lib/typings/index.d.js",
   "author": {
     "name": "Zhongliang Wang",
     "email": "zwang@rebelworks.io",

--- a/packages/builders/builder-typescript/src/index.ts
+++ b/packages/builders/builder-typescript/src/index.ts
@@ -5,11 +5,18 @@ import transpile from './utils/transpile';
 const typescriptBuilderPlugin: BuilderPlugin = {
   name: 'TypeScript Builder',
   supportedExtensions: ['ts'],
-  async buildConfigFile({ configFilePath, destDir, verbose, importHelpers }) {
+  async buildConfigFile({
+    configFilePath,
+    destDir,
+    verbose,
+    importHelpers,
+    transpileModule,
+  }) {
     const compiledFilePath = build({
       fileName: configFilePath,
       destDir,
       verbose,
+      transpileModule,
       importHelpers,
     });
     if (compiledFilePath) {

--- a/packages/builders/builder-typescript/src/index.ts
+++ b/packages/builders/builder-typescript/src/index.ts
@@ -5,13 +5,13 @@ import transpile from './utils/transpile';
 const typescriptBuilderPlugin: BuilderPlugin = {
   name: 'TypeScript Builder',
   supportedExtensions: ['ts'],
-  async buildConfigFile(configFilePath, destDir, verbose, importHelpers) {
-    const compiledFilePath = build(
-      configFilePath,
+  async buildConfigFile({ configFilePath, destDir, verbose, importHelpers }) {
+    const compiledFilePath = build({
+      fileName: configFilePath,
       destDir,
       verbose,
       importHelpers,
-    );
+    });
     if (compiledFilePath) {
       return compiledFilePath;
     } else {

--- a/packages/builders/builder-typescript/src/transformer/index.ts
+++ b/packages/builders/builder-typescript/src/transformer/index.ts
@@ -80,7 +80,8 @@ export function createTransformer(importHelpers: boolean, destDir?: string) {
         const srcFullName = path.basename(
           sourceFile.fileName.replace(/\.ts$/g, '.d.ts'),
         );
-        // Write down the declaration file if targetDir and targetFileName are specified
+        // Write down the declaration file if targetDir is specified
+        fs.mkdirSync(destDir);
         fs.writeFileSync(
           path.resolve(destDir, srcFullName),
           declarationFile.join('\n'),

--- a/packages/builders/builder-typescript/src/utils/build.ts
+++ b/packages/builders/builder-typescript/src/utils/build.ts
@@ -18,7 +18,7 @@ export default function build({
   verbose?: boolean;
   importHelpers?: boolean;
 }) {
-  const MantaStyleTranformer = createTransformer(importHelpers);
+  const MantaStyleTranformer = createTransformer(importHelpers, destDir);
   const program = ts.createProgram([fileName], {
     strict: true,
     noEmitOnError: true,

--- a/packages/builders/builder-typescript/src/utils/build.ts
+++ b/packages/builders/builder-typescript/src/utils/build.ts
@@ -8,11 +8,13 @@ import { createTransformer } from '../transformer';
 export default function build({
   fileName,
   destDir,
+  transpileModule,
   verbose = false,
   importHelpers = true,
 }: {
   fileName: string;
   destDir: string;
+  transpileModule: boolean;
   verbose?: boolean;
   importHelpers?: boolean;
 }) {
@@ -38,20 +40,22 @@ export default function build({
   if (verbose) {
     console.log('[TYPESCRIPT] Compile Result', result);
   }
-  const jsModuleFiles = glob.sync(path.join(destDir, '**/*.js'));
-  for (const file of jsModuleFiles) {
-    if (verbose) {
-      console.log('[BABEL] Processing file: ' + file);
-    }
-    const result = babelCore.transformFileSync(file, {
-      presets: [require('@babel/preset-env')],
-      plugins: [require('@babel/plugin-transform-modules-commonjs')],
-    });
+  if (transpileModule) {
+    const jsModuleFiles = glob.sync(path.join(destDir, '**/*.js'));
+    for (const file of jsModuleFiles) {
+      if (verbose) {
+        console.log('[BABEL] Processing file: ' + file);
+      }
+      const result = babelCore.transformFileSync(file, {
+        presets: [require('@babel/preset-env')],
+        plugins: [require('@babel/plugin-transform-modules-commonjs')],
+      });
 
-    if (result) {
-      fs.writeFileSync(file, result.code);
-    } else {
-      throw new Error('Babel failed to compile the config file.');
+      if (result) {
+        fs.writeFileSync(file, result.code);
+      } else {
+        throw new Error('Babel failed to compile the config file.');
+      }
     }
   }
   return (

--- a/packages/builders/builder-typescript/src/utils/build.ts
+++ b/packages/builders/builder-typescript/src/utils/build.ts
@@ -5,12 +5,17 @@ import * as glob from 'glob';
 import * as babelCore from '@babel/core';
 import { createTransformer } from '../transformer';
 
-export default function build(
-  fileName: string,
-  destDir: string,
-  verbose: boolean = false,
-  importHelpers: boolean = true,
-) {
+export default function build({
+  fileName,
+  destDir,
+  verbose = false,
+  importHelpers = true,
+}: {
+  fileName: string;
+  destDir: string;
+  verbose?: boolean;
+  importHelpers?: boolean;
+}) {
   const MantaStyleTranformer = createTransformer(importHelpers);
   const program = ts.createProgram([fileName], {
     strict: true,

--- a/packages/builders/builder-typescript/tsconfig.json
+++ b/packages/builders/builder-typescript/tsconfig.json
@@ -3,8 +3,10 @@
   "compilerOptions": {
     "target": "es5",
     "module": "esnext",
+    "baseUrl": "./",
     "declaration": true,
     "declarationDir": "./lib/typings"
   },
+  "include": ["./src/**/*"],
   "exclude": ["./lib"]
 }

--- a/packages/core/cli/package.json
+++ b/packages/core/cli/package.json
@@ -24,6 +24,7 @@
     "watch": "tsc --watch -p tsconfig.json"
   },
   "devDependencies": {
+    "@manta-style/builder-flowtype": "^0.2.0-alpha.7",
     "@manta-style/builder-typescript": "^0.2.0-alpha.7",
     "@manta-style/helpers": "^0.2.0-alpha.7",
     "@types/chokidar": "^1.7.5",
@@ -45,6 +46,7 @@
     "@manta-style/runtime": "^0.2.0-alpha.7",
     "@manta-style/server-restful": "^0.2.0-alpha.7",
     "@manta-style/typescript-helpers": "^0.2.0-alpha.7",
+    "@manta-style/flowtype-helpers": "^0.2.0-alpha.7",
     "axios": "^0.18.0",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.4",

--- a/packages/core/cli/package.json
+++ b/packages/core/cli/package.json
@@ -41,12 +41,12 @@
   },
   "dependencies": {
     "@manta-style/core": "^0.2.0-alpha.7",
+    "@manta-style/flowtype-helpers": "^0.2.0-alpha.7",
     "@manta-style/mock-example": "^0.2.0-alpha.7",
     "@manta-style/mock-range": "^0.2.0-alpha.7",
     "@manta-style/runtime": "^0.2.0-alpha.7",
     "@manta-style/server-restful": "^0.2.0-alpha.7",
     "@manta-style/typescript-helpers": "^0.2.0-alpha.7",
-    "@manta-style/flowtype-helpers": "^0.2.0-alpha.7",
     "axios": "^0.18.0",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.4",
@@ -60,6 +60,7 @@
     "pretty-error": "^2.1.1",
     "query-string": "^6.2.0",
     "read-pkg-up": "^4.0.0",
-    "resolve-from": "^4.0.0"
+    "resolve-from": "^4.0.0",
+    "rollup": "^0.67.3"
   }
 }

--- a/packages/core/cli/src/index.ts
+++ b/packages/core/cli/src/index.ts
@@ -142,11 +142,11 @@ async function showOfficialPluginList() {
       server.close();
     }
     const app = express();
-    const compiledFilePath = await core.buildConfigFile(
-      path.resolve(configFile),
-      tmpDir,
+    const compiledFilePath = await core.buildConfigFile({
+      configFilePath: path.resolve(configFile),
+      destDir: tmpDir,
       verbose,
-    );
+    });
 
     delete require.cache[compiledFilePath];
 

--- a/packages/core/cli/src/index.ts
+++ b/packages/core/cli/src/index.ts
@@ -17,11 +17,12 @@ import { multiSelect } from './inquirer-util';
 import { MantaStyleContext, CompiledTypes, Core } from '@manta-style/core';
 import { findPlugins } from './discovery';
 import { rollup } from 'rollup';
+import * as Package from '../package.json';
 
 const pe = new PrettyError();
 
 program
-  .version('0.2.0')
+  .version(Package.version)
   .option('-c --configFile <file>', 'the config file to generate entry points')
   .option('-p --port <i> [3000]', 'To use a port different than 3000')
   .option(

--- a/packages/core/cli/src/index.ts
+++ b/packages/core/cli/src/index.ts
@@ -16,6 +16,7 @@ import clear = require('clear');
 import { multiSelect } from './inquirer-util';
 import { MantaStyleContext, CompiledTypes, Core } from '@manta-style/core';
 import { findPlugins } from './discovery';
+import { rollup } from 'rollup';
 
 const pe = new PrettyError();
 
@@ -23,6 +24,10 @@ program
   .version('0.2.0')
   .option('-c --configFile <file>', 'the config file to generate entry points')
   .option('-p --port <i> [3000]', 'To use a port different than 3000')
+  .option(
+    '-o --outputFile <file>',
+    'Instead of setting up a server, output a single file for various purpose',
+  )
   .option('--proxyUrl <url>', 'To enable proxy for disabled endpoints')
   .option(
     '--generateSnapshot <file>',
@@ -36,6 +41,7 @@ program
 const {
   officialPlugins,
   configFile,
+  outputFile,
   port,
   generateSnapshot,
   useSnapshot,
@@ -107,15 +113,39 @@ async function showOfficialPluginList() {
     );
   }
 
+  const tmpDir = path.join(findRoot(process.cwd()), '.mantastyle-tmp');
+
+  function buildFromConfigFile(transpileModule: boolean = true) {
+    return core.buildConfigFile({
+      configFilePath: path.resolve(configFile),
+      destDir: tmpDir,
+      transpileModule,
+      verbose,
+    });
+  }
+
+  if (outputFile) {
+    const resolvedPath = path.resolve(outputFile);
+    const compiledPath = await buildFromConfigFile(false);
+    console.log('Compiling to', outputFile, 'from', compiledPath);
+    const bundle = await rollup({
+      input: compiledPath,
+    });
+    await bundle.write({
+      file: path.basename(resolvedPath),
+      dir: path.dirname(resolvedPath),
+      format: 'cjs',
+      sourcemap: true,
+    });
+    process.exit(0);
+  }
+
   let server: Server | undefined;
 
   const snapshotFilePath = path.join(
     path.dirname(configFile),
     'ms.snapshot.json',
   );
-
-  const tmpDir = path.join(findRoot(process.cwd()), '.mantastyle-tmp');
-
   const snapshotWatcher = chokidar.watch(snapshotFilePath);
   const configFileWatcher = chokidar.watch(path.resolve(configFile));
 
@@ -142,11 +172,7 @@ async function showOfficialPluginList() {
       server.close();
     }
     const app = express();
-    const compiledFilePath = await core.buildConfigFile({
-      configFilePath: path.resolve(configFile),
-      destDir: tmpDir,
-      verbose,
-    });
+    const compiledFilePath = await buildFromConfigFile();
 
     delete require.cache[compiledFilePath];
 

--- a/packages/core/cli/src/index.ts
+++ b/packages/core/cli/src/index.ts
@@ -135,7 +135,6 @@ async function showOfficialPluginList() {
       file: path.basename(resolvedPath),
       dir: path.dirname(resolvedPath),
       format: 'cjs',
-      sourcemap: true,
     });
     process.exit(0);
   }

--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -69,12 +69,12 @@ export class Core {
   }
 }
 
-export abstract class Type {
+export abstract class Type<T = any> {
   public abstract deriveLiteral(
     parentAnnotations: Annotation[],
     context: MantaStyleContext,
-  ): Promise<Type>;
-  public mock(): any {
+  ): Promise<Type<T>>;
+  public mock(): T {
     throw new Error('Literal types should be derived before mock.');
   }
   public abstract validate(
@@ -89,3 +89,9 @@ export abstract class CustomType extends Type {
     context: MantaStyleContext,
   ): Promise<Type>;
 }
+
+export const EmptyContext: MantaStyleContext = {
+  query: {},
+  param: {},
+  plugins: PluginSystem.default(),
+};

--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -40,16 +40,19 @@ export class Core {
   public buildConfigFile({
     configFilePath,
     destDir,
+    transpileModule,
     verbose,
   }: {
     configFilePath: string;
     destDir: string;
+    transpileModule: boolean;
     verbose?: boolean;
   }) {
     this.endpoints = [];
     return this.pluginSystem.buildConfigFile({
       configFilePath,
       destDir,
+      transpileModule,
       verbose,
     });
   }

--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -66,6 +66,10 @@ export abstract class Type {
   public mock(): any {
     throw new Error('Literal types should be derived before mock.');
   }
+  public abstract validate(
+    value: unknown,
+    context: MantaStyleContext,
+  ): Promise<boolean>;
 }
 
 export abstract class CustomType extends Type {

--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -37,13 +37,21 @@ export class Core {
   public getEndpoints() {
     return this.endpoints;
   }
-  public buildConfigFile(
-    configFilePath: string,
-    destDir: string,
-    verbose?: boolean,
-  ) {
+  public buildConfigFile({
+    configFilePath,
+    destDir,
+    verbose,
+  }: {
+    configFilePath: string;
+    destDir: string;
+    verbose?: boolean;
+  }) {
     this.endpoints = [];
-    return this.pluginSystem.buildConfigFile(configFilePath, destDir, verbose);
+    return this.pluginSystem.buildConfigFile({
+      configFilePath,
+      destDir,
+      verbose,
+    });
   }
   public generateEndpoints(
     compiled: CompiledTypes,

--- a/packages/core/core/src/plugin/index.ts
+++ b/packages/core/core/src/plugin/index.ts
@@ -57,6 +57,7 @@ export interface BuilderPlugin {
   buildConfigFile(options: {
     configFilePath: string;
     destDir: string;
+    transpileModule: boolean;
     verbose?: boolean;
     importHelpers?: boolean;
   }): Promise<string>;
@@ -149,11 +150,13 @@ export class PluginSystem {
   public async buildConfigFile({
     configFilePath,
     destDir,
+    transpileModule,
     verbose,
     importHelpers,
   }: {
     configFilePath: string;
     destDir: string;
+    transpileModule: boolean;
     verbose?: boolean;
     importHelpers?: boolean;
   }): Promise<string> {
@@ -163,6 +166,7 @@ export class PluginSystem {
       return handler.buildConfigFile({
         configFilePath,
         destDir,
+        transpileModule,
         verbose,
         importHelpers,
       });

--- a/packages/core/core/src/plugin/index.ts
+++ b/packages/core/core/src/plugin/index.ts
@@ -54,12 +54,12 @@ export interface MockPlugin {
 export interface BuilderPlugin {
   name: string;
   supportedExtensions: string[];
-  buildConfigFile(
-    configFilePath: string,
-    destDir: string,
-    verbose?: boolean,
-    importHelpers?: boolean,
-  ): Promise<string>;
+  buildConfigFile(options: {
+    configFilePath: string;
+    destDir: string;
+    verbose?: boolean;
+    importHelpers?: boolean;
+  }): Promise<string>;
   buildConfigSource(sourceCode: string): Promise<string>;
 }
 
@@ -146,21 +146,26 @@ export class PluginSystem {
     }
     return null;
   }
-  public async buildConfigFile(
-    configFilePath: string,
-    destDir: string,
-    verbose?: boolean,
-    importHelpers?: boolean,
-  ): Promise<string> {
+  public async buildConfigFile({
+    configFilePath,
+    destDir,
+    verbose,
+    importHelpers,
+  }: {
+    configFilePath: string;
+    destDir: string;
+    verbose?: boolean;
+    importHelpers?: boolean;
+  }): Promise<string> {
     const extension = extractNormalizedExtension(configFilePath);
     const handler = this.builderPlugins[extension];
     if (handler) {
-      return handler.buildConfigFile(
+      return handler.buildConfigFile({
         configFilePath,
         destDir,
         verbose,
         importHelpers,
-      );
+      });
     } else {
       throw new Error(
         generateErrorMessage(ErrorCode.UNSUPPORTED_EXTENSION, extension),

--- a/packages/core/flowtype-helpers/script/build.js
+++ b/packages/core/flowtype-helpers/script/build.js
@@ -1,9 +1,9 @@
 // @ts-check
 const { build } = require('@manta-style/builder-typescript');
 const path = require('path');
-build(
-  path.join(__dirname, '..', 'src', 'index.ts'),
-  path.join(__dirname, '..', 'lib'),
-  true,
-  false,
-);
+build({
+  fileName: path.join(__dirname, '..', 'src', 'index.ts'),
+  destDir: path.join(__dirname, '..', 'lib'),
+  verbose: true,
+  importHelpers: false,
+});

--- a/packages/core/flowtype-helpers/script/build.js
+++ b/packages/core/flowtype-helpers/script/build.js
@@ -5,5 +5,6 @@ build({
   fileName: path.join(__dirname, '..', 'src', 'index.ts'),
   destDir: path.join(__dirname, '..', 'lib'),
   verbose: true,
+  transpileModule: true,
   importHelpers: false,
 });

--- a/packages/core/helpers/package.json
+++ b/packages/core/helpers/package.json
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "devDependencies": {
-    "@manta-style/core": "^0.2.0-alpha.6",
-    "@manta-style/runtime": "^0.2.0-alpha.6",
+    "@manta-style/core": "^0.2.0-alpha.7",
+    "@manta-style/runtime": "^0.2.0-alpha.7",
     "awesome-typescript-loader": "^5.2.1",
     "source-map-loader": "^0.2.4",
     "typescript": "3.1.1",

--- a/packages/core/helpers/src/types/DelayType.ts
+++ b/packages/core/helpers/src/types/DelayType.ts
@@ -33,6 +33,9 @@ export default class DelayType extends CustomType {
     }
     return type.deriveLiteral(annotations, context);
   }
+  public validate(value: unknown, context: MantaStyleContext) {
+    return this.type.validate(value, context);
+  }
   public typeForAssignabilityTest(
     annotations: Annotation[],
     context: MantaStyleContext,

--- a/packages/core/helpers/src/types/ParamType.ts
+++ b/packages/core/helpers/src/types/ParamType.ts
@@ -21,24 +21,31 @@ export default class ParamType extends CustomType {
   ) {
     return this.deriveLiteral(annotations, context);
   }
+  public async getParamContent(context: MantaStyleContext) {
+    const { param } = context;
+    const { type } = await resolveReferencedType(this.type, context);
+    if (type instanceof LiteralType && typeof param === 'object') {
+      return param[type.mock()];
+    }
+  }
   public async deriveLiteral(
     annotations: Annotation[],
     context: MantaStyleContext,
   ) {
-    const { param } = context;
-    const { type } = await resolveReferencedType(this.type, context);
-    if (type instanceof LiteralType && typeof param === 'object') {
-      const content = param[type.mock()];
-      if (content) {
-        if (typeof content === 'string') {
-          return MantaStyle.Literal(content);
-        } else if (Array.isArray(content)) {
-          return MantaStyle.ArrayLiteral(
-            content.map((item) => MantaStyle.Literal(item)),
-          );
-        }
+    const content = await this.getParamContent(context);
+    if (content) {
+      if (typeof content === 'string') {
+        return MantaStyle.Literal(content);
+      } else if (Array.isArray(content)) {
+        return MantaStyle.ArrayLiteral(
+          content.map((item) => MantaStyle.Literal(item)),
+        );
       }
     }
     return MantaStyle.NeverKeyword;
+  }
+  public async validate(value: unknown, context: MantaStyleContext) {
+    const content = await this.getParamContent(context);
+    return value === content;
   }
 }

--- a/packages/core/helpers/src/types/UnsplashType.ts
+++ b/packages/core/helpers/src/types/UnsplashType.ts
@@ -6,6 +6,8 @@ import {
   CustomType,
 } from '@manta-style/core';
 
+const UNSPLASH_PREFIX = 'https://source.unsplash.com';
+
 export default class UnsplashType extends CustomType {
   private readonly keyword: Type;
   private readonly width: Type;
@@ -20,7 +22,7 @@ export default class UnsplashType extends CustomType {
     return MantaStyle.StringKeyword;
   }
   public async validate(value: unknown) {
-    return typeof value === 'string';
+    return typeof value === 'string' && value.startsWith(UNSPLASH_PREFIX);
   }
   public async deriveLiteral(
     annotations: Annotation[],
@@ -43,7 +45,7 @@ export default class UnsplashType extends CustomType {
     ])).map((itemType) => itemType.mock());
 
     return MantaStyle.Literal(
-      `https://source.unsplash.com/${width}x${height}/?${keyword}`,
+      `${UNSPLASH_PREFIX}/${width}x${height}/?${keyword}`,
     );
   }
 }

--- a/packages/core/helpers/src/types/UnsplashType.ts
+++ b/packages/core/helpers/src/types/UnsplashType.ts
@@ -19,6 +19,9 @@ export default class UnsplashType extends CustomType {
   public async typeForAssignabilityTest() {
     return MantaStyle.StringKeyword;
   }
+  public async validate(value: unknown) {
+    return typeof value === 'string';
+  }
   public async deriveLiteral(
     annotations: Annotation[],
     context: MantaStyleContext,

--- a/packages/core/runtime/.npmignore
+++ b/packages/core/runtime/.npmignore
@@ -1,3 +1,5 @@
 src/
+benchmark/
+coverage/
 tsconfig.json
 webpack.config.js

--- a/packages/core/runtime/__tests__/types/AnyKeyword.ts
+++ b/packages/core/runtime/__tests__/types/AnyKeyword.ts
@@ -7,4 +7,11 @@ describe('AnyKeyword', () => {
   test('mock', () => {
     expect(MS.AnyKeyword.mock).toThrowError();
   });
+  test('validate', async () => {
+    expect(await MS.AnyKeyword.validate(3)).toBe(true);
+    expect(await MS.AnyKeyword.validate({})).toBe(true);
+    expect(await MS.AnyKeyword.validate('hahah')).toBe(true);
+    expect(await MS.AnyKeyword.validate(false)).toBe(true);
+    expect(await MS.AnyKeyword.validate([])).toBe(true);
+  });
 });

--- a/packages/core/runtime/__tests__/types/ArrayType.ts
+++ b/packages/core/runtime/__tests__/types/ArrayType.ts
@@ -23,7 +23,7 @@ describe('AnyKeyword', () => {
     )).mock();
     expect(data.length).toBe(10);
   });
-  test('validate', async () => {
+  test('validate: ArrayType', async () => {
     expect(await type.validate(3, context)).toBe(false);
     expect(await type.validate({}, context)).toBe(false);
     expect(await type.validate('hahah', context)).toBe(false);
@@ -32,5 +32,25 @@ describe('AnyKeyword', () => {
     expect(await type.validate([1, 2, 3], context)).toBe(true);
     expect(await type.validate([1, '2', 3], context)).toBe(false);
     expect(await type.validate(['1', '2', '3'], context)).toBe(false);
+  });
+  test('validate: ArrayLiteral', async () => {
+    const arrayLiteralType = MS.ArrayLiteral([
+      MS.Literal('a'),
+      MS.Literal('b'),
+      MS.Literal('c'),
+    ]);
+    expect(await arrayLiteralType.validate(3, context)).toBe(false);
+    expect(await arrayLiteralType.validate({}, context)).toBe(false);
+    expect(await arrayLiteralType.validate('hahah', context)).toBe(false);
+    expect(await arrayLiteralType.validate(false, context)).toBe(false);
+    expect(await arrayLiteralType.validate([], context)).toBe(false);
+    expect(await arrayLiteralType.validate([1, 2, 3], context)).toBe(false);
+    expect(await arrayLiteralType.validate([1, '2', 3], context)).toBe(false);
+    expect(await arrayLiteralType.validate(['1', '2', '3'], context)).toBe(
+      false,
+    );
+    expect(await arrayLiteralType.validate(['a', 'b', 'c'], context)).toBe(
+      true,
+    );
   });
 });

--- a/packages/core/runtime/__tests__/types/ArrayType.ts
+++ b/packages/core/runtime/__tests__/types/ArrayType.ts
@@ -23,4 +23,14 @@ describe('AnyKeyword', () => {
     )).mock();
     expect(data.length).toBe(10);
   });
+  test('validate', async () => {
+    expect(await type.validate(3, context)).toBe(false);
+    expect(await type.validate({}, context)).toBe(false);
+    expect(await type.validate('hahah', context)).toBe(false);
+    expect(await type.validate(false, context)).toBe(false);
+    expect(await type.validate([], context)).toBe(true);
+    expect(await type.validate([1, 2, 3], context)).toBe(true);
+    expect(await type.validate([1, '2', 3], context)).toBe(false);
+    expect(await type.validate(['1', '2', '3'], context)).toBe(false);
+  });
 });

--- a/packages/core/runtime/__tests__/types/BooleanKeyword.ts
+++ b/packages/core/runtime/__tests__/types/BooleanKeyword.ts
@@ -1,0 +1,19 @@
+import MS from '../../src';
+import { PluginSystem } from '@manta-style/core';
+
+describe('Boolean Test', () => {
+  const booleanKeyword = MS.BooleanKeyword;
+  const context = { query: {}, param: {}, plugins: PluginSystem.default() };
+  test('BooleanKeyword can mock', async () => {
+    const result = (await booleanKeyword.deriveLiteral([], context)).mock();
+    expect(typeof result).toBe('boolean');
+  });
+  test('BooleanKeyword can validate', async () => {
+    expect(await booleanKeyword.validate(3)).toBe(false);
+    expect(await booleanKeyword.validate({})).toBe(false);
+    expect(await booleanKeyword.validate('string')).toBe(false);
+    expect(await booleanKeyword.validate(false)).toBe(true);
+    expect(await booleanKeyword.validate([])).toBe(false);
+    expect(await booleanKeyword.validate('haha')).toBe(false);
+  });
+});

--- a/packages/core/runtime/__tests__/types/ConditionalType.ts
+++ b/packages/core/runtime/__tests__/types/ConditionalType.ts
@@ -3,26 +3,36 @@ import { PluginSystem } from '@manta-style/core';
 
 describe('ConditionalType', () => {
   const context = { query: {}, param: {}, plugins: PluginSystem.default() };
-  test('1 extends number ? true : false / "haha" extends number ? true : false', async () => {
-    const literalOne = MS.Literal(1);
-    const literalHaha = MS.Literal('haha');
-    const literalTrue = MS.Literal(true);
-    const literalFalse = MS.Literal(false);
-    const conditionNumber = MS.ConditionalType(
-      literalOne,
-      MS.NumberKeyword,
-      literalTrue,
-      literalFalse,
+  const literalOne = MS.Literal(1);
+  const literalHaha = MS.Literal('haha');
+  const literalTrue = MS.Literal(true);
+  const literalFalse = MS.Literal(false);
+  const conditionNumber = MS.ConditionalType(
+    literalOne,
+    MS.NumberKeyword,
+    literalTrue,
+    literalFalse,
+  );
+  const conditionString = MS.ConditionalType(
+    literalHaha,
+    MS.NumberKeyword,
+    literalTrue,
+    literalFalse,
+  );
+  test('DeriveLiteral: 1 extends number ? true : false / "haha" extends number ? true : false', async () => {
+    const expectedLiteralTrue = await conditionNumber.deriveLiteral(
+      [],
+      context,
     );
-    const conditionString = MS.ConditionalType(
-      literalHaha,
-      MS.NumberKeyword,
-      literalTrue,
-      literalFalse,
+    const expectedLiteralFalse = await conditionString.deriveLiteral(
+      [],
+      context,
     );
-    const expectedTypeNumber = await conditionNumber.deriveLiteral([], context);
-    const expectedTypeString = await conditionString.deriveLiteral([], context);
-    expect(expectedTypeNumber).toBe(literalTrue);
-    expect(expectedTypeString).toBe(literalFalse);
+    expect(expectedLiteralTrue).toBe(literalTrue);
+    expect(expectedLiteralFalse).toBe(literalFalse);
+  });
+  test('Validate: 1 extends number ? true : false / "haha" extends number ? true : false', async () => {
+    expect(await conditionNumber.validate(true, context)).toBe(true);
+    expect(await conditionString.validate(false, context)).toBe(true);
   });
 });

--- a/packages/core/runtime/__tests__/types/IndexedAccess.ts
+++ b/packages/core/runtime/__tests__/types/IndexedAccess.ts
@@ -19,6 +19,8 @@ describe('IndexedAccessType', () => {
     const indexedAccess = MS.IndexedAccessType(obj, MS.Literal('a'));
     const literalOne = await indexedAccess.deriveLiteral([], context);
     expect(literalOne.mock()).toEqual(1);
+    expect(await literalOne.validate(1, context)).toBe(true);
+    expect(await literalOne.validate(2, context)).toBe(false);
   });
   test('T[keyof T]; a.k.a $Values<T>', async () => {
     /*
@@ -42,5 +44,8 @@ describe('IndexedAccessType', () => {
     } else {
       throw Error('Result is not a UnionType.');
     }
+    expect(await result.validate(1, context)).toBe(true);
+    expect(await result.validate(2, context)).toBe(true);
+    expect(await result.validate(3, context)).toBe(false);
   });
 });

--- a/packages/core/runtime/__tests__/types/KeyOfKeyword.ts
+++ b/packages/core/runtime/__tests__/types/KeyOfKeyword.ts
@@ -2,15 +2,17 @@ import MS from '../../src';
 import { PluginSystem } from '@manta-style/core';
 
 describe('KeyOfKeyword', () => {
+  /* type Obj = { a:number, b:number, c:number, d:number } */
+  const obj = MS.TypeLiteral((currentType) => {
+    currentType.property('a', MS.NumberKeyword, false, []);
+    currentType.property('b', MS.NumberKeyword, false, []);
+    currentType.property('c', MS.NumberKeyword, false, []);
+    currentType.property('d', MS.NumberKeyword, false, []);
+  });
+  /* type KeyOfObj = keyof Obj */
+  const keyOfObj = MS.KeyOfKeyword(obj);
   const context = { query: {}, param: {}, plugins: PluginSystem.default() };
   test('Basic properties', async () => {
-    const obj = MS.TypeLiteral((currentType) => {
-      currentType.property('a', MS.NumberKeyword, false, []);
-      currentType.property('b', MS.NumberKeyword, false, []);
-      currentType.property('c', MS.NumberKeyword, false, []);
-      currentType.property('d', MS.NumberKeyword, false, []);
-    });
-    const keyOfObj = MS.KeyOfKeyword(obj);
     const abcdUnion = await keyOfObj.deriveLiteral([], context);
     expect(abcdUnion.getTypes().map((item) => item.mock())).toEqual([
       'a',
@@ -18,5 +20,12 @@ describe('KeyOfKeyword', () => {
       'c',
       'd',
     ]);
+  });
+  test('Validate', async () => {
+    expect(await keyOfObj.validate('a', context)).toBe(true);
+    expect(await keyOfObj.validate('b', context)).toBe(true);
+    expect(await keyOfObj.validate('c', context)).toBe(true);
+    expect(await keyOfObj.validate('d', context)).toBe(true);
+    expect(await keyOfObj.validate('e', context)).toBe(false);
   });
 });

--- a/packages/core/runtime/__tests__/types/Literals.ts
+++ b/packages/core/runtime/__tests__/types/Literals.ts
@@ -1,0 +1,17 @@
+import MS from '../../src';
+
+describe('Literals Test', () => {
+  const stringLiteral = MS.Literal('haha');
+  test('Literal can mock', async () => {
+    const result = (await stringLiteral.deriveLiteral()).mock();
+    expect(result).toBe('haha');
+  });
+  test('Literal can validate', async () => {
+    expect(await stringLiteral.validate(3)).toBe(false);
+    expect(await stringLiteral.validate({})).toBe(false);
+    expect(await stringLiteral.validate('string')).toBe(false);
+    expect(await stringLiteral.validate(false)).toBe(false);
+    expect(await stringLiteral.validate([])).toBe(false);
+    expect(await stringLiteral.validate('haha')).toBe(true);
+  });
+});

--- a/packages/core/runtime/__tests__/types/NeverKeyword.ts
+++ b/packages/core/runtime/__tests__/types/NeverKeyword.ts
@@ -1,0 +1,10 @@
+import MS from '../../src';
+
+describe('NeverKeyword', () => {
+  test('mock', () => {
+    expect(MS.NeverKeyword.mock).toThrowError();
+  });
+  test('validate', async () => {
+    expect(MS.NeverKeyword.validate).toThrowError();
+  });
+});

--- a/packages/core/runtime/__tests__/types/NullKeyword.ts
+++ b/packages/core/runtime/__tests__/types/NullKeyword.ts
@@ -5,6 +5,6 @@ describe('NullKeyword', () => {
     expect(MS.NullKeyword.mock()).toBe(null);
   });
   test('validate', async () => {
-    expect(MS.NullKeyword.validate(null)).toBe(true);
+    expect(await MS.NullKeyword.validate(null)).toBe(true);
   });
 });

--- a/packages/core/runtime/__tests__/types/NullKeyword.ts
+++ b/packages/core/runtime/__tests__/types/NullKeyword.ts
@@ -1,0 +1,10 @@
+import MS from '../../src';
+
+describe('NullKeyword', () => {
+  test('mock', () => {
+    expect(MS.NullKeyword.mock()).toBe(null);
+  });
+  test('validate', async () => {
+    expect(MS.NullKeyword.validate(null)).toBe(true);
+  });
+});

--- a/packages/core/runtime/__tests__/types/OptionalType.ts
+++ b/packages/core/runtime/__tests__/types/OptionalType.ts
@@ -17,4 +17,20 @@ describe('OptionalType', () => {
       typeof result[2] === 'number' || typeof result[2] === 'undefined',
     ).toBe(true);
   });
+  test('validate', async () => {
+    /* type Tuple = ['haha', 'heihei', 'hoho'?] */
+    const tuple = MS.TupleType([
+      MS.Literal('haha'),
+      MS.Literal('heihei'),
+      MS.OptionalType(MS.Literal('hoho')),
+    ]);
+    expect(await tuple.validate(['haha', 'heihei'], context)).toBe(true);
+    expect(await tuple.validate(['haha', 'heihei', 'hoho'], context)).toBe(
+      true,
+    );
+    expect(await tuple.validate(['haha', 'heihei', 'lala'], context)).toBe(
+      false,
+    );
+    expect(await tuple.validate(['haha'], context)).toBe(false);
+  });
 });

--- a/packages/core/runtime/__tests__/types/TypeLiteral.ts
+++ b/packages/core/runtime/__tests__/types/TypeLiteral.ts
@@ -3,20 +3,34 @@ import { PluginSystem } from '@manta-style/core';
 
 describe('TypeLiteral Test', () => {
   const context = { query: {}, param: {}, plugins: PluginSystem.default() };
-
-  test('TypeLiteral can mock', async () => {
-    const GenericTypeLiteral = MS.TypeAliasDeclaration(
-      'GenericTypeLiteral',
-      (type) => {
-        const T = type.TypeParameter('T');
-        return MS.TypeLiteral((currentType) => {
-          currentType.property('test', T, false, []);
-        });
-      },
-      [],
-    );
+  /*
+   type GenericTypeLiteral<T> = {
+     test: T
+   }
+  */
+  const GenericTypeLiteral = MS.TypeAliasDeclaration(
+    'GenericTypeLiteral',
+    (type) => {
+      const T = type.TypeParameter('T');
+      return MS.TypeLiteral((currentType) => {
+        currentType.property('test', T, false, []);
+      });
+    },
+    [],
+  );
+  test('mock', async () => {
     const TestObject = GenericTypeLiteral.argumentTypes([MS.NumberKeyword]);
     const result = (await TestObject.deriveLiteral([], context)).mock();
     expect(typeof result.test === 'number').toBe(true);
+  });
+  test('validate (simple case)', async () => {
+    const TestObject = GenericTypeLiteral.argumentTypes([MS.NumberKeyword]);
+    expect(await TestObject.validate(3, context)).toBe(false);
+    expect(await TestObject.validate({}, context)).toBe(false);
+    expect(await TestObject.validate('hahah', context)).toBe(false);
+    expect(await TestObject.validate(false, context)).toBe(false);
+    expect(await TestObject.validate([], context)).toBe(false);
+    expect(await TestObject.validate({ test: 'haha' }, context)).toBe(false);
+    expect(await TestObject.validate({ test: 123 }, context)).toBe(true);
   });
 });

--- a/packages/core/runtime/benchmark/typeLiteralValidation.js
+++ b/packages/core/runtime/benchmark/typeLiteralValidation.js
@@ -1,0 +1,61 @@
+// @ts-check
+const { default: MS } = require('@manta-style/runtime');
+const { PluginSystem } = require('@manta-style/core');
+const prettyHrTime = require('pretty-hrtime');
+
+const context = { query: {}, param: {}, plugins: PluginSystem.default() };
+
+const HelperType = MS.TypeAliasDeclaration(
+  'TestType',
+  () =>
+    MS.TypeLiteral((currentType) => {
+      currentType.property('a', MS.BooleanKeyword, false, []);
+      currentType.property('b', MS.StringKeyword, false, []);
+      currentType.property(
+        'c',
+        MS.UnionType([MS.NullKeyword, MS.StringKeyword]),
+        false,
+        [],
+      );
+      currentType.property('d', MS.BooleanKeyword, false, []);
+      currentType.property('e', MS.BooleanKeyword, false, []);
+    }),
+  [],
+);
+
+const TestType = MS.TypeAliasDeclaration(
+  'TestType',
+  () =>
+    MS.TypeLiteral((currentType) => {
+      currentType.property('a', MS.NumberKeyword, false, []);
+      currentType.property('b', HelperType, false, []);
+      currentType.property('c', MS.NumberKeyword, false, []);
+      currentType.property('d', HelperType, false, []);
+      currentType.property('e', MS.NumberKeyword, false, []);
+      currentType.property('f', HelperType, false, []);
+    }),
+  [],
+);
+
+async function benchmark() {
+  const timeStart = process.hrtime();
+  let result = false;
+  for (let i = 0; i < 100000; i++) {
+    result = await TestType.validate(
+      {
+        a: 134,
+        b: { a: true, b: 'heiheihei', c: null, d: false, e: true },
+        c: 495,
+        d: { a: true, b: 'hoho', c: 'yes', d: true, e: true },
+        e: 391,
+        f: { a: true, b: 'zzz', c: 'elel', d: false, e: true },
+      },
+      context,
+    );
+  }
+  const timeEnd = process.hrtime(timeStart);
+  console.log(prettyHrTime(timeEnd), 'Result is', result);
+  console.log(process.memoryUsage().heapUsed / 1024 / 1024, 'MB');
+}
+
+benchmark();

--- a/packages/core/runtime/package.json
+++ b/packages/core/runtime/package.json
@@ -28,6 +28,7 @@
     "@types/lodash-es": "^4.17.1",
     "awesome-typescript-loader": "^5.2.1",
     "jest": "^23.6.0",
+    "pretty-hrtime": "^1.0.3",
     "source-map-loader": "^0.2.4",
     "ts-jest": "^23.10.3",
     "typescript": "3.1.1",
@@ -36,7 +37,8 @@
   },
   "dependencies": {
     "@manta-style/core": "^0.2.0-alpha.7",
-    "lodash-es": "^4.17.11"
+    "lodash-es": "^4.17.11",
+    "tslib": "^1.9.3"
   },
   "jest": {
     "transform": {

--- a/packages/core/runtime/src/nodes/LazyTypeAliasDeclaration.ts
+++ b/packages/core/runtime/src/nodes/LazyTypeAliasDeclaration.ts
@@ -42,6 +42,10 @@ export default class LazyTypeAliasDeclaration extends TypeAliasDeclaration {
     return super.deriveLiteral(parentAnnotations, context);
   }
 
+  public async validate(value: unknown, context: MantaStyleContext) {
+    return super.validate(value, context);
+  }
+
   public argumentTypes(types: Type[]) {
     // need to create a different instance of TypeAliasDeclaration
     // for each call of argumentTypes(...);

--- a/packages/core/runtime/src/nodes/LazyTypeAliasDeclaration.ts
+++ b/packages/core/runtime/src/nodes/LazyTypeAliasDeclaration.ts
@@ -43,6 +43,7 @@ export default class LazyTypeAliasDeclaration extends TypeAliasDeclaration {
   }
 
   public async validate(value: unknown, context: MantaStyleContext) {
+    this.initialize();
     return super.validate(value, context);
   }
 

--- a/packages/core/runtime/src/nodes/TypeAliasDeclaration.ts
+++ b/packages/core/runtime/src/nodes/TypeAliasDeclaration.ts
@@ -83,4 +83,14 @@ export default class TypeAliasDeclaration extends Type {
     }
     return this.type.deriveLiteral(combinedAnnotations, context);
   }
+  public async validate(value: unknown, context: MantaStyleContext) {
+    for (let i = 0; i < this.typeParameterTypes.length; i++) {
+      const { type } = await resolveReferencedType(
+        this.typeParameterTypes[i],
+        context,
+      );
+      await this.typeParameters[i].setActualType(type, context);
+    }
+    return this.type.validate(value, context);
+  }
 }

--- a/packages/core/runtime/src/nodes/TypeParameter.ts
+++ b/packages/core/runtime/src/nodes/TypeParameter.ts
@@ -40,4 +40,7 @@ export default class TypeParameter extends Type {
   ) {
     return this.getActualType().deriveLiteral(parentAnnotations, context);
   }
+  public validate(value: unknown, context: MantaStyleContext) {
+    return this.getActualType().validate(value, context);
+  }
 }

--- a/packages/core/runtime/src/types/AnyKeyword.ts
+++ b/packages/core/runtime/src/types/AnyKeyword.ts
@@ -4,4 +4,7 @@ export default class AnyKeyword extends Type {
   public async deriveLiteral() {
     return this;
   }
+  public async validate(value: unknown) {
+    return true;
+  }
 }

--- a/packages/core/runtime/src/types/ArrayLiteral.ts
+++ b/packages/core/runtime/src/types/ArrayLiteral.ts
@@ -1,4 +1,5 @@
-import { Type } from '@manta-style/core';
+import { Type, MantaStyleContext } from '@manta-style/core';
+import { everyPromise } from '../utils/assignable';
 
 export default class ArrayLiteral extends Type {
   private readonly elements: Type[];
@@ -12,10 +13,15 @@ export default class ArrayLiteral extends Type {
   public async deriveLiteral() {
     return this;
   }
-  public async validate(value: unknown) {
+  public async validate(value: unknown, context: MantaStyleContext) {
     return (
       Array.isArray(value) &&
-      value.every((item, index) => item === this.elements[index])
+      value.length === this.elements.length &&
+      (await everyPromise(
+        value.map((item, index) =>
+          this.elements[index].validate(item, context),
+        ),
+      ))
     );
   }
   public mock() {

--- a/packages/core/runtime/src/types/ArrayLiteral.ts
+++ b/packages/core/runtime/src/types/ArrayLiteral.ts
@@ -12,6 +12,12 @@ export default class ArrayLiteral extends Type {
   public async deriveLiteral() {
     return this;
   }
+  public async validate(value: unknown) {
+    return (
+      Array.isArray(value) &&
+      value.every((item, index) => item === this.elements[index])
+    );
+  }
   public mock() {
     return this.elements.map((type) => type.mock());
   }

--- a/packages/core/runtime/src/types/ArrayType.ts
+++ b/packages/core/runtime/src/types/ArrayType.ts
@@ -5,6 +5,7 @@ import {
   annotationUtils,
   Type,
 } from '@manta-style/core';
+import { everyPromise } from '../utils/assignable';
 
 export default class ArrayType extends Type {
   private elementType: Type;
@@ -31,5 +32,13 @@ export default class ArrayType extends Type {
       array.push(await this.elementType.deriveLiteral(annotations, context));
     }
     return new ArrayLiteral(array);
+  }
+  public async validate(value: unknown, context: MantaStyleContext) {
+    return (
+      Array.isArray(value) &&
+      (await everyPromise(
+        value.map((item) => this.elementType.validate(item, context)),
+      ))
+    );
   }
 }

--- a/packages/core/runtime/src/types/BooleanKeyword.ts
+++ b/packages/core/runtime/src/types/BooleanKeyword.ts
@@ -16,4 +16,7 @@ export default class BooleanKeyword extends Type {
       typeof pluginValue === 'boolean' ? pluginValue : Math.random() >= 0.5,
     );
   }
+  public async validate(value: unknown) {
+    return typeof value === 'boolean';
+  }
 }

--- a/packages/core/runtime/src/types/ConditionalType.ts
+++ b/packages/core/runtime/src/types/ConditionalType.ts
@@ -22,10 +22,7 @@ export default class ConditionalType extends Type {
     this.trueType = trueType;
     this.falseType = falseType;
   }
-  public async deriveLiteral(
-    annotations: Annotation[],
-    context: MantaStyleContext,
-  ) {
+  private async getResolvedType(context: MantaStyleContext) {
     /*
       From: http://koerbitz.me/posts/a-look-at-typescripts-conditional-types.html
       The Distributive Rule of Conditional and Union Types
@@ -67,7 +64,7 @@ export default class ConditionalType extends Type {
         ),
         context,
       );
-      return resolvedType.deriveLiteral(annotations, context);
+      return resolvedType;
     } else {
       const resolvedType = await resolveConditionalType(
         checkType,
@@ -76,8 +73,19 @@ export default class ConditionalType extends Type {
         falseType,
         context,
       );
-      return resolvedType.deriveLiteral(annotations, context);
+      return resolvedType;
     }
+  }
+  public async deriveLiteral(
+    annotations: Annotation[],
+    context: MantaStyleContext,
+  ) {
+    const resolvedType = await this.getResolvedType(context);
+    return resolvedType.deriveLiteral(annotations, context);
+  }
+  public async validate(value: unknown, context: MantaStyleContext) {
+    const resolvedType = await this.getResolvedType(context);
+    return resolvedType.validate(value, context);
   }
 }
 

--- a/packages/core/runtime/src/types/IntersectionType.ts
+++ b/packages/core/runtime/src/types/IntersectionType.ts
@@ -1,6 +1,7 @@
 import { resolveReferencedType } from '../utils/referenceTypes';
 import { intersection } from '../utils/intersection';
 import { Annotation, MantaStyleContext, Type } from '@manta-style/core';
+import { everyPromise } from '../utils/assignable';
 
 export default class IntersectionType extends Type {
   private readonly types: Type[];
@@ -20,6 +21,11 @@ export default class IntersectionType extends Type {
       reducedType = await intersection(reducedType, type, context);
     }
     return reducedType.deriveLiteral(parentAnnotations, context);
+  }
+  public validate(value: unknown, context: MantaStyleContext) {
+    return everyPromise(
+      this.types.map((type) => type.validate(value, context)),
+    );
   }
   public getTypes() {
     return this.types;

--- a/packages/core/runtime/src/types/KeyOfKeyword.ts
+++ b/packages/core/runtime/src/types/KeyOfKeyword.ts
@@ -29,4 +29,8 @@ export default class KeyOfKeyword extends Type {
     const keys = await this.getKeys(context);
     return new UnionType(keys.map((key) => new Literal(key)));
   }
+  public async validate(value: unknown, context: MantaStyleContext) {
+    const keys = await this.getKeys(context);
+    return typeof value === 'string' && keys.includes(value);
+  }
 }

--- a/packages/core/runtime/src/types/Literal.ts
+++ b/packages/core/runtime/src/types/Literal.ts
@@ -10,6 +10,9 @@ export default class Literal<T extends Literals> extends Type {
   public async deriveLiteral() {
     return this;
   }
+  public async validate(value: unknown) {
+    return value === this.literal;
+  }
   public mock() {
     return this.literal;
   }

--- a/packages/core/runtime/src/types/MappedType.ts
+++ b/packages/core/runtime/src/types/MappedType.ts
@@ -86,6 +86,9 @@ export default class MappedType extends Type {
       );
     }
   }
+  public validate(): never {
+    throw Error('MappedType does not support validation yet');
+  }
   public TypeParameter(name: string) {
     const newTypeParam = new TypeParameter(name);
     this.typeParameter = newTypeParam;

--- a/packages/core/runtime/src/types/NeverKeyword.ts
+++ b/packages/core/runtime/src/types/NeverKeyword.ts
@@ -5,6 +5,6 @@ export default class NeverKeyword extends Type {
     return this;
   }
   public validate(): never {
-    throw Error('`never` keyword does not support `validate` method.');
+    throw new Error('`never` keyword does not support `validate` method.');
   }
 }

--- a/packages/core/runtime/src/types/NeverKeyword.ts
+++ b/packages/core/runtime/src/types/NeverKeyword.ts
@@ -4,4 +4,7 @@ export default class NeverKeyword extends Type {
   public async deriveLiteral() {
     return this;
   }
+  public validate(): never {
+    throw Error('`never` keyword does not support `validate` method.');
+  }
 }

--- a/packages/core/runtime/src/types/NullKeyword.ts
+++ b/packages/core/runtime/src/types/NullKeyword.ts
@@ -1,4 +1,4 @@
-import { Type } from '@manta-style/core';
+import { Type, MantaStyleContext } from '@manta-style/core';
 
 export default class NullKeyword extends Type {
   public async deriveLiteral() {
@@ -6,5 +6,8 @@ export default class NullKeyword extends Type {
   }
   public mock() {
     return null;
+  }
+  public async validate(value: unknown) {
+    return value === null;
   }
 }

--- a/packages/core/runtime/src/types/NullableType.ts
+++ b/packages/core/runtime/src/types/NullableType.ts
@@ -2,6 +2,7 @@ import { Annotation, MantaStyleContext, Type } from '@manta-style/core';
 import UnionType from './UnionType';
 import NullKeyword from './NullKeyword';
 import UndefinedKeyword from './UndefinedKeyword';
+import MantaStyle from '..';
 
 export default class NullableType extends Type {
   private type: Type;
@@ -20,6 +21,13 @@ export default class NullableType extends Type {
     context: MantaStyleContext,
   ) {
     return this.nullableType.deriveLiteral(annotations, context);
+  }
+  public async validate(value: unknown, context: MantaStyleContext) {
+    return (
+      this.type.validate(value, context) ||
+      MantaStyle.UndefinedKeyword.validate(value) ||
+      MantaStyle.NullKeyword.validate(value)
+    );
   }
   public _getUnderlyingType() {
     return this.type;

--- a/packages/core/runtime/src/types/NumberKeyword.ts
+++ b/packages/core/runtime/src/types/NumberKeyword.ts
@@ -16,4 +16,7 @@ export default class NumberKeyword extends Type {
       pluginValue !== null ? Number(pluginValue) : Math.random() * 100;
     return new Literal(numberValue);
   }
+  public async validate(value: unknown) {
+    return typeof value === 'number';
+  }
 }

--- a/packages/core/runtime/src/types/ObjectKeyword.ts
+++ b/packages/core/runtime/src/types/ObjectKeyword.ts
@@ -5,4 +5,7 @@ export default class ObjectKeyword extends Type {
   public async deriveLiteral() {
     return new TypeLiteral();
   }
+  public async validate(value: unknown) {
+    return typeof value === 'object';
+  }
 }

--- a/packages/core/runtime/src/types/OptionalType.ts
+++ b/packages/core/runtime/src/types/OptionalType.ts
@@ -1,4 +1,5 @@
 import { Annotation, MantaStyleContext, Type } from '@manta-style/core';
+import MantaStyle from '..';
 
 export default class OptionalType extends Type {
   private type: Type;
@@ -6,10 +7,13 @@ export default class OptionalType extends Type {
     super();
     this.type = type;
   }
-  public async deriveLiteral(
-    annotations: Annotation[],
-    context: MantaStyleContext,
-  ) {
+  public deriveLiteral(annotations: Annotation[], context: MantaStyleContext) {
     return this.type.deriveLiteral(annotations, context);
+  }
+  public validate(value: unknown, context: MantaStyleContext) {
+    return (
+      this.type.validate(value, context) ||
+      MantaStyle.UndefinedKeyword.validate(value)
+    );
   }
 }

--- a/packages/core/runtime/src/types/ParenthesizedType.ts
+++ b/packages/core/runtime/src/types/ParenthesizedType.ts
@@ -9,10 +9,10 @@ export default class ParenthesizedType extends Type {
   public getType() {
     return this.type;
   }
-  public async deriveLiteral(
-    annotations: Annotation[],
-    context: MantaStyleContext,
-  ) {
+  public deriveLiteral(annotations: Annotation[], context: MantaStyleContext) {
     return this.type.deriveLiteral(annotations, context);
+  }
+  public validate(value: unknown, context: MantaStyleContext) {
+    return this.type.validate(value, context);
   }
 }

--- a/packages/core/runtime/src/types/StringKeyword.ts
+++ b/packages/core/runtime/src/types/StringKeyword.ts
@@ -19,4 +19,7 @@ export default class StringKeyword extends Type {
       pluginValue !== null ? String(pluginValue) : DEFAULT_STATIC_STRING;
     return new Literal(stringValue);
   }
+  public async validate(value: unknown) {
+    return typeof value === 'string';
+  }
 }

--- a/packages/core/runtime/src/types/UndefinedKeyword.ts
+++ b/packages/core/runtime/src/types/UndefinedKeyword.ts
@@ -7,4 +7,7 @@ export default class UndefinedKeyword extends Type {
   public mock() {
     return undefined;
   }
+  public async validate(value: unknown) {
+    return typeof value === 'undefined';
+  }
 }

--- a/packages/core/runtime/src/types/UnionType.ts
+++ b/packages/core/runtime/src/types/UnionType.ts
@@ -2,6 +2,7 @@ import { sample } from 'lodash-es';
 import NeverKeyword from './NeverKeyword';
 import { resolveReferencedType } from '../utils/referenceTypes';
 import { Annotation, MantaStyleContext, Type } from '@manta-style/core';
+import { somePromise } from '../utils/assignable';
 
 export default class UnionType extends Type {
   private readonly types: Type[] = [];
@@ -52,6 +53,9 @@ export default class UnionType extends Type {
       return chosenType.mock();
     }
     throw Error('Something bad happens :(');
+  }
+  public validate(value: unknown, context: MantaStyleContext) {
+    return somePromise(this.types.map((type) => type.validate(value, context)));
   }
   public getTypes(): Type[] {
     return this.types;

--- a/packages/core/runtime/src/utils/assignable.ts
+++ b/packages/core/runtime/src/utils/assignable.ts
@@ -108,10 +108,12 @@ export async function isAssignable(
   return false;
 }
 
-async function everyPromise(array: Promise<boolean>[]): Promise<boolean> {
+export async function everyPromise(
+  array: Promise<boolean>[],
+): Promise<boolean> {
   return (await Promise.all(array)).every((t) => t);
 }
 
-async function somePromise(array: Promise<boolean>[]): Promise<boolean> {
+export async function somePromise(array: Promise<boolean>[]): Promise<boolean> {
   return (await Promise.all(array)).some((t) => t);
 }

--- a/packages/core/runtime/src/utils/pseudoTypes.ts
+++ b/packages/core/runtime/src/utils/pseudoTypes.ts
@@ -9,6 +9,9 @@ export class ErrorType extends Type {
   public async deriveLiteral() {
     return this;
   }
+  public validate(): never {
+    throw Error('ErrorType does not support `validate` method.');
+  }
   public mock() {
     throw new Error(this.message);
   }

--- a/packages/core/runtime/tsconfig.json
+++ b/packages/core/runtime/tsconfig.json
@@ -5,6 +5,7 @@
     "strict": true,
     "sourceMap": true,
     "module": "esnext",
+    "esModuleInterop": true,
     "declaration": true,
     "declarationDir": "./lib/typings"
   },

--- a/packages/core/runtime/tsconfig.json
+++ b/packages/core/runtime/tsconfig.json
@@ -5,6 +5,8 @@
     "strict": true,
     "sourceMap": true,
     "module": "esnext",
+    "noEmitHelpers": true,
+    "importHelpers": true,
     "esModuleInterop": true,
     "declaration": true,
     "declarationDir": "./lib/typings"

--- a/packages/core/runtime/webpack.config.js
+++ b/packages/core/runtime/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
   },
   externals: {
     '@manta-style/core': '@manta-style/core',
+    tslib: 'tslib',
   },
   module: {
     rules: [

--- a/packages/core/typescript-helpers/package.json
+++ b/packages/core/typescript-helpers/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0-alpha.7",
   "description": "Manta Style Helper for TypeScript",
   "main": "./lib/index.js",
+  "typings": "./lib/index.d.ts",
   "author": {
     "name": "Zhongliang Wang",
     "email": "zwang@rebelworks.io",

--- a/packages/core/typescript-helpers/script/build.js
+++ b/packages/core/typescript-helpers/script/build.js
@@ -1,9 +1,9 @@
 // @ts-check
 const { build } = require('@manta-style/builder-typescript');
 const path = require('path');
-build(
-  path.join(__dirname, '..', 'src', 'index.ts'),
-  path.join(__dirname, '..', 'lib'),
-  true,
-  false,
-);
+build({
+  fileName: path.join(__dirname, '..', 'src', 'index.ts'),
+  destDir: path.join(__dirname, '..', 'lib'),
+  verbose: true,
+  importHelpers: false,
+});

--- a/packages/core/typescript-helpers/script/build.js
+++ b/packages/core/typescript-helpers/script/build.js
@@ -4,6 +4,7 @@ const path = require('path');
 build({
   fileName: path.join(__dirname, '..', 'src', 'index.ts'),
   destDir: path.join(__dirname, '..', 'lib'),
+  transpileModule: true,
   verbose: true,
   importHelpers: false,
 });

--- a/packages/mocks/mock-faker/webpack.config.js
+++ b/packages/mocks/mock-faker/webpack.config.js
@@ -1,34 +1,34 @@
 module.exports = {
-    mode: 'production',
-    entry: __dirname + '/src/index.ts',
-    devtool: 'source-map',
-    target: 'node',
-    output: {
-        path: __dirname + '/lib',
-        filename: 'index.js',
-        library: 'MantaStylePluginMockFaker',
-        libraryTarget: 'umd',
-        // See https://github.com/webpack/webpack/issues/6522
-        globalObject: "typeof self !== 'undefined' ? self : this",
-        umdNamedDefine: true,
-    },
-    resolve: {
-        extensions: ['.ts', '.tsx', '.js', '.json'],
-    },
-    module: {
-        rules: [
-            {
-                test: /\.tsx?$/,
-                use: ['awesome-typescript-loader'],
-            },
-            {
-                test: /\.js$/,
-                use: ['source-map-loader'],
-                enforce: 'pre',
-            },
-        ],
-    },
-    performance: {
-        hints: false,
-    },
+  mode: 'production',
+  entry: __dirname + '/src/index.ts',
+  devtool: 'source-map',
+  target: 'node',
+  output: {
+    path: __dirname + '/lib',
+    filename: 'index.js',
+    library: 'MantaStylePluginMockFaker',
+    libraryTarget: 'umd',
+    // See https://github.com/webpack/webpack/issues/6522
+    globalObject: "typeof self !== 'undefined' ? self : this",
+    umdNamedDefine: true,
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.json'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: ['awesome-typescript-loader'],
+      },
+      {
+        test: /\.js$/,
+        use: ['source-map-loader'],
+        enforce: 'pre',
+      },
+    ],
+  },
+  performance: {
+    hints: false,
+  },
 };

--- a/packages/mocks/mock-iterate/webpack.config.js
+++ b/packages/mocks/mock-iterate/webpack.config.js
@@ -1,34 +1,34 @@
 module.exports = {
-    mode: 'production',
-    entry: __dirname + '/src/index.ts',
-    devtool: 'source-map',
-    target: 'node',
-    output: {
-        path: __dirname + '/lib',
-        filename: 'index.js',
-        library: 'MantaStylePluginMockFaker',
-        libraryTarget: 'umd',
-        // See https://github.com/webpack/webpack/issues/6522
-        globalObject: "typeof self !== 'undefined' ? self : this",
-        umdNamedDefine: true,
-    },
-    resolve: {
-        extensions: ['.ts', '.tsx', '.js', '.json'],
-    },
-    module: {
-        rules: [
-            {
-                test: /\.tsx?$/,
-                use: ['awesome-typescript-loader'],
-            },
-            {
-                test: /\.js$/,
-                use: ['source-map-loader'],
-                enforce: 'pre',
-            },
-        ],
-    },
-    performance: {
-        hints: false,
-    },
+  mode: 'production',
+  entry: __dirname + '/src/index.ts',
+  devtool: 'source-map',
+  target: 'node',
+  output: {
+    path: __dirname + '/lib',
+    filename: 'index.js',
+    library: 'MantaStylePluginMockFaker',
+    libraryTarget: 'umd',
+    // See https://github.com/webpack/webpack/issues/6522
+    globalObject: "typeof self !== 'undefined' ? self : this",
+    umdNamedDefine: true,
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.json'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: ['awesome-typescript-loader'],
+      },
+      {
+        test: /\.js$/,
+        use: ['source-map-loader'],
+        enforce: 'pre',
+      },
+    ],
+  },
+  performance: {
+    hints: false,
+  },
 };

--- a/packages/mocks/mock-qotd/webpack.config.js
+++ b/packages/mocks/mock-qotd/webpack.config.js
@@ -1,34 +1,34 @@
 module.exports = {
-    mode: 'production',
-    entry: __dirname + '/src/index.ts',
-    devtool: 'source-map',
-    target: 'node',
-    output: {
-        path: __dirname + '/lib',
-        filename: 'index.js',
-        library: 'MantaStylePluginMockQotD',
-        libraryTarget: 'umd',
-        // See https://github.com/webpack/webpack/issues/6522
-        globalObject: "typeof self !== 'undefined' ? self : this",
-        umdNamedDefine: true,
-    },
-    resolve: {
-        extensions: ['.ts', '.tsx', '.js', '.json'],
-    },
-    module: {
-        rules: [
-            {
-                test: /\.tsx?$/,
-                use: ['awesome-typescript-loader'],
-            },
-            {
-                test: /\.js$/,
-                use: ['source-map-loader'],
-                enforce: 'pre',
-            },
-        ],
-    },
-    performance: {
-        hints: false,
-    },
+  mode: 'production',
+  entry: __dirname + '/src/index.ts',
+  devtool: 'source-map',
+  target: 'node',
+  output: {
+    path: __dirname + '/lib',
+    filename: 'index.js',
+    library: 'MantaStylePluginMockQotD',
+    libraryTarget: 'umd',
+    // See https://github.com/webpack/webpack/issues/6522
+    globalObject: "typeof self !== 'undefined' ? self : this",
+    umdNamedDefine: true,
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.json'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: ['awesome-typescript-loader'],
+      },
+      {
+        test: /\.js$/,
+        use: ['source-map-loader'],
+        enforce: 'pre',
+      },
+    ],
+  },
+  performance: {
+    hints: false,
+  },
 };

--- a/packages/mocks/mock-range/webpack.config.js
+++ b/packages/mocks/mock-range/webpack.config.js
@@ -1,34 +1,34 @@
 module.exports = {
-    mode: 'production',
-    entry: __dirname + '/src/index.ts',
-    devtool: 'source-map',
-    target: 'node',
-    output: {
-        path: __dirname + '/lib',
-        filename: 'index.js',
-        library: 'MantaStylePluginMockFaker',
-        libraryTarget: 'umd',
-        // See https://github.com/webpack/webpack/issues/6522
-        globalObject: "typeof self !== 'undefined' ? self : this",
-        umdNamedDefine: true,
-    },
-    resolve: {
-        extensions: ['.ts', '.tsx', '.js', '.json'],
-    },
-    module: {
-        rules: [
-            {
-                test: /\.tsx?$/,
-                use: ['awesome-typescript-loader'],
-            },
-            {
-                test: /\.js$/,
-                use: ['source-map-loader'],
-                enforce: 'pre',
-            },
-        ],
-    },
-    performance: {
-        hints: false,
-    },
+  mode: 'production',
+  entry: __dirname + '/src/index.ts',
+  devtool: 'source-map',
+  target: 'node',
+  output: {
+    path: __dirname + '/lib',
+    filename: 'index.js',
+    library: 'MantaStylePluginMockFaker',
+    libraryTarget: 'umd',
+    // See https://github.com/webpack/webpack/issues/6522
+    globalObject: "typeof self !== 'undefined' ? self : this",
+    umdNamedDefine: true,
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.json'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: ['awesome-typescript-loader'],
+      },
+      {
+        test: /\.js$/,
+        use: ['source-map-loader'],
+        enforce: 'pre',
+      },
+    ],
+  },
+  performance: {
+    hints: false,
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,6 +1277,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
@@ -7631,6 +7636,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rollup@^0.67.3:
+  version "0.67.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.67.3.tgz#55475b1b62c43220c3b4bd7edc5846233932f50b"
+  integrity sha512-TyNQCz97rKuVVbsKUTXfwIjV7UljWyTVd7cTMuE+aqlQ7WJslkYF5QaYGjMLR2BlQtUOO5CAxSVnpQ55iYp5jg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    "@types/node" "*"
 
 rsvp@^3.3.3:
   version "3.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7053,6 +7053,11 @@ pretty-format@^23.6.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+pretty-hrtime@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
+  integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
+
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -8459,7 +8464,7 @@ ts-jest@^23.10.3:
     semver "^5.5"
     yargs-parser "10.x"
 
-tslib@^1.9.0:
+tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==


### PR DESCRIPTION
Close #79

Add a new CLI option `--outputFile` which outputs the compiled file (and corresponding type declaration) only.

## Usage
```ts
// interface.ts
export type GetItemRequest = {
  productId: number;
}
``` 

### Compile `interface.ts`
```bash
ms --configFile interface.ts --outputFile interface.js
```

### Install dependencies and copy over `interface.js` and `interface.d.ts`
```bash
yarn add @manta-style/runtime @manta-style/core
```

### Use it
```js
import { GetItemRequest } from './interface';
import { EmptyContext } from '@manta-style/core';

async function validateUserInput(value) {
  return await GetItemRequest.validate(value, EmptyContext);
}
```

**Now you get runtime validation that respects to your type definition**

TODO (not in this PR):
- [ ] Remove the param `context` in `validate` (with some trade-offs)
- [ ] Make `validate` synchronous

Note: This PR is blocking our full-stack scaffolding tool based on Egg.js with E2E type coverage support.

