### PR TITLE
Format Feature

### DIFF
--- a/packages/builders/builder-typescript/src/transformer/utils.ts
+++ b/packages/builders/builder-typescript/src/transformer/utils.ts
@@ -221,7 +221,7 @@ function createTypeLiteralProperties(
               member.questionToken ? ts.createTrue() : ts.createFalse(),
               generateJSDocParam(jsdocArray),
             ],
-            'typeLiteral',
+            '$$typeLiteral',
           ),
         ),
       );
@@ -244,7 +244,7 @@ function createTypeLiteralProperties(
                   member.questionToken ? ts.createTrue() : ts.createFalse(),
                   generateJSDocParam(jsdocArray),
                 ],
-                'typeLiteral',
+                '$$typeLiteral',
               ),
             ),
           );
@@ -387,7 +387,7 @@ export function createTypeLiteral(
           undefined,
           undefined,
           undefined,
-          'typeLiteral',
+          '$$typeLiteral',
           undefined,
           undefined,
           undefined,

--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -69,6 +69,7 @@ export abstract class Type<T = any> {
     throw new Error('Literal types should be derived before mock.');
   }
   public abstract validate(value: unknown): value is T;
+  public abstract format(value: unknown): T;
 }
 
 export abstract class CustomType extends Type {

--- a/packages/core/helpers/src/types/ParamType.ts
+++ b/packages/core/helpers/src/types/ParamType.ts
@@ -37,4 +37,12 @@ export default class ParamType extends CustomType {
     const content = this.getParamContent();
     return value === content;
   }
+  public format(value: unknown) {
+    const content = this.getParamContent();
+    if (value == content) {
+      return content;
+    } else {
+      throw new Error('Cannot format as the value cannot be validated.');
+    }
+  }
 }

--- a/packages/core/helpers/src/types/QueryType.ts
+++ b/packages/core/helpers/src/types/QueryType.ts
@@ -37,4 +37,12 @@ export default class QueryType extends CustomType {
     const content = this.getQueryContent();
     return value === content;
   }
+  public format(value: unknown) {
+    const content = this.getQueryContent();
+    if (value == content) {
+      return content;
+    } else {
+      throw new Error('Cannot format as the value cannot be validated.');
+    }
+  }
 }

--- a/packages/core/helpers/src/types/UnsplashType.ts
+++ b/packages/core/helpers/src/types/UnsplashType.ts
@@ -19,6 +19,13 @@ export default class UnsplashType extends CustomType {
   public validate(value: unknown): value is any {
     return typeof value === 'string' && value.startsWith(UNSPLASH_PREFIX);
   }
+  public format(value: unknown) {
+    if (this.validate(value)) {
+      return value;
+    } else {
+      return this.deriveLiteral([]).mock();
+    }
+  }
   public deriveLiteral(annotations: Annotation[]) {
     const [{ type: keywordType }, { type: widthType }, { type: heightType }] = [
       resolveReferencedType(this.keyword),

--- a/packages/core/runtime/__tests__/types/BooleanKeyword.ts
+++ b/packages/core/runtime/__tests__/types/BooleanKeyword.ts
@@ -14,4 +14,13 @@ describe('Boolean Test', () => {
     expect(booleanKeyword.validate([])).toBe(false);
     expect(booleanKeyword.validate('haha')).toBe(false);
   });
+  test('BooleanKeyword can format', () => {
+    expect(() => booleanKeyword.format(3)).toThrow();
+    expect(booleanKeyword.format(1)).toBe(true);
+    expect(booleanKeyword.format(0)).toBe(false);
+    expect(booleanKeyword.format('')).toBe(false);
+    expect(booleanKeyword.format(true)).toBe(true);
+    expect(booleanKeyword.format(false)).toBe(false);
+    expect(() => booleanKeyword.format('haha')).toThrow();
+  });
 });

--- a/packages/core/runtime/__tests__/types/Literals.ts
+++ b/packages/core/runtime/__tests__/types/Literals.ts
@@ -2,6 +2,7 @@ import MS from '../../src';
 
 describe('Literals Test', () => {
   const stringLiteral = MS.Literal('haha');
+  const numberLikeStringLiteral = MS.Literal('3');
   test('Literal can mock', () => {
     const result = stringLiteral.deriveLiteral().mock();
     expect(result).toBe('haha');
@@ -13,5 +14,8 @@ describe('Literals Test', () => {
     expect(stringLiteral.validate(false)).toBe(false);
     expect(stringLiteral.validate([])).toBe(false);
     expect(stringLiteral.validate('haha')).toBe(true);
+  });
+  test('Literal can format', () => {
+    expect(numberLikeStringLiteral.format(3)).toBe('3');
   });
 });

--- a/packages/core/runtime/__tests__/types/NumberKeyword.ts
+++ b/packages/core/runtime/__tests__/types/NumberKeyword.ts
@@ -1,0 +1,28 @@
+import MS from '../../src';
+
+describe('Number Test', () => {
+  const numberKeyword = MS.NumberKeyword;
+  test('NumberKeyword can mock', () => {
+    const result = numberKeyword.deriveLiteral([]).mock();
+    expect(typeof result).toBe('number');
+  });
+  test('Number can validate', () => {
+    expect(numberKeyword.validate(3)).toBe(true);
+    expect(numberKeyword.validate({})).toBe(false);
+    expect(numberKeyword.validate('string')).toBe(false);
+    expect(numberKeyword.validate(false)).toBe(false);
+    expect(numberKeyword.validate([])).toBe(false);
+    expect(numberKeyword.validate('haha')).toBe(false);
+  });
+  test('NumberKeyword can format', () => {
+    expect(numberKeyword.format(3)).toBe(3);
+    expect(numberKeyword.format('3')).toBe(3);
+    expect(numberKeyword.format('3.1415')).toBe(3.1415);
+    expect(numberKeyword.format('-3.1415')).toBe(-3.1415);
+    expect(() => numberKeyword.format('3.14.15')).toThrow();
+    expect(numberKeyword.format('')).toBe(0);
+    expect(() => numberKeyword.format(true)).toThrow();
+    expect(() => numberKeyword.format(false)).toThrow();
+    expect(() => numberKeyword.format('haha')).toThrow();
+  });
+});

--- a/packages/core/runtime/__tests__/types/TypeLiteral.ts
+++ b/packages/core/runtime/__tests__/types/TypeLiteral.ts
@@ -31,4 +31,66 @@ describe('TypeLiteral Test', () => {
     expect(TestObject.validate({ test: 'haha' })).toBe(false);
     expect(TestObject.validate({ test: 123 })).toBe(true);
   });
+  test('format', () => {
+    /*
+   type TestGenerics = {
+     zz: number
+   }
+   type TestFormat<T> = {
+     heihei: {
+       x: boolean,
+       y: string
+       z: T,
+       a: 0 | 1 | '2'
+     }
+   }
+  */
+    const TestGenerics = MS.TypeAliasDeclaration(
+      'TestGenerics',
+      () => {
+        return MS.TypeLiteral((currentType) => {
+          currentType.property('zz', MS.NumberKeyword, false, []);
+        });
+      },
+      [],
+    );
+    const TestFormat = MS.TypeAliasDeclaration(
+      'TestFormat',
+      (type) => {
+        const T = type.TypeParameter('T');
+        return MS.TypeLiteral((currentType) => {
+          currentType.property(
+            'heihei',
+            MS.TypeLiteral((ct) => {
+              ct.property('x', MS.BooleanKeyword, false, []);
+              ct.property('y', MS.StringKeyword, false, []);
+              ct.property('z', T, false, []);
+              ct.property(
+                'a',
+                MS.UnionType([MS.Literal(0), MS.Literal(1), MS.Literal('2')]),
+                false,
+                [],
+              );
+            }),
+            false,
+            [],
+          );
+        });
+      },
+      [],
+    );
+    const TestObject = TestFormat.argumentTypes([TestGenerics]);
+    expect(
+      TestObject.format({ heihei: { x: 1, y: 222, z: { zz: '3' }, a: 2 } }),
+    ).toEqual({
+      heihei: {
+        x: true,
+        y: '222',
+        z: {
+          zz: 3,
+        },
+        a: '2',
+      },
+    });
+  });
 });

--- a/packages/core/runtime/__tests__/types/TypeLiteral.ts
+++ b/packages/core/runtime/__tests__/types/TypeLiteral.ts
@@ -31,7 +31,26 @@ describe('TypeLiteral Test', () => {
     expect(TestObject.validate({ test: 'haha' })).toBe(false);
     expect(TestObject.validate({ test: 123 })).toBe(true);
   });
-  test('format', () => {
+  test('format (simple case)', () => {
+    /**
+     * type TestGenerics = {
+     *   zz: number
+     * }
+     */
+    const TestSimple = MS.TypeAliasDeclaration(
+      'TestSimple',
+      () => {
+        return MS.TypeLiteral((currentType) => {
+          currentType.property('zz', MS.NumberKeyword, false, []);
+        });
+      },
+      [],
+    );
+    expect(TestSimple.format({ zz: '333' })).toEqual({ zz: 333 });
+    expect(TestSimple.format({ zz: 333 })).toEqual({ zz: 333 });
+    expect(() => TestSimple.format({ zz: 'heihei' })).toThrow();
+  });
+  test('format (complex case)', () => {
     /*
    type TestGenerics = {
      zz: number

--- a/packages/core/runtime/benchmark/typeLiteralValidation.js
+++ b/packages/core/runtime/benchmark/typeLiteralValidation.js
@@ -49,8 +49,7 @@ async function benchmark() {
         d: { a: true, b: 'hoho', c: 'yes', d: true, e: true },
         e: 391,
         f: { a: true, b: 'zzz', c: 'elel', d: false, e: true },
-      },
-      context,
+      }
     );
   }
   const timeEnd = process.hrtime(timeStart);

--- a/packages/core/runtime/src/nodes/LazyTypeAliasDeclaration.ts
+++ b/packages/core/runtime/src/nodes/LazyTypeAliasDeclaration.ts
@@ -44,6 +44,11 @@ export default class LazyTypeAliasDeclaration extends TypeAliasDeclaration {
     return super.validate(value);
   }
 
+  public format(value: unknown) {
+    this.initialize();
+    return super.format(value);
+  }
+
   public argumentTypes(types: Type[]) {
     // need to create a different instance of TypeAliasDeclaration
     // for each call of argumentTypes(...);

--- a/packages/core/runtime/src/nodes/TypeAliasDeclaration.ts
+++ b/packages/core/runtime/src/nodes/TypeAliasDeclaration.ts
@@ -79,4 +79,11 @@ export default class TypeAliasDeclaration extends Type {
     }
     return this.type.validate(value);
   }
+  public format(value: unknown) {
+    for (let i = 0; i < this.typeParameterTypes.length; i++) {
+      const { type } = resolveReferencedType(this.typeParameterTypes[i]);
+      this.typeParameters[i].setActualType(type);
+    }
+    return this.type.format(value);
+  }
 }

--- a/packages/core/runtime/src/nodes/TypeParameter.ts
+++ b/packages/core/runtime/src/nodes/TypeParameter.ts
@@ -37,4 +37,7 @@ export default class TypeParameter extends Type {
   public validate(value: unknown): value is any {
     return this.getActualType().validate(value);
   }
+  public format(value: unknown) {
+    return this.getActualType().format(value);
+  }
 }

--- a/packages/core/runtime/src/types/AnyKeyword.ts
+++ b/packages/core/runtime/src/types/AnyKeyword.ts
@@ -7,4 +7,7 @@ export default class AnyKeyword extends Type {
   public validate(value: unknown): value is any {
     return true;
   }
+  public format(value: unknown) {
+    return value;
+  }
 }

--- a/packages/core/runtime/src/types/ArrayLiteral.ts
+++ b/packages/core/runtime/src/types/ArrayLiteral.ts
@@ -12,7 +12,6 @@ export default class ArrayLiteral extends Type {
   public deriveLiteral() {
     return this;
   }
-  // TODO: Fix type guard
   public validate(value: unknown): value is any[] {
     return (
       Array.isArray(value) &&
@@ -22,5 +21,11 @@ export default class ArrayLiteral extends Type {
   }
   public mock() {
     return this.elements.map((type) => type.mock());
+  }
+  public format(value: unknown) {
+    if (Array.isArray(value) && value.length === this.elements.length) {
+      return this.elements.map((type, index) => type.format(value[index]));
+    }
+    throw new Error('Cannot format as the value cannot be validated.');
   }
 }

--- a/packages/core/runtime/src/types/ArrayType.ts
+++ b/packages/core/runtime/src/types/ArrayType.ts
@@ -30,4 +30,10 @@ export default class ArrayType extends Type {
       value.every((item) => this.elementType.validate(item))
     );
   }
+  public format(value: unknown) {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.elementType.format(item));
+    }
+    throw new Error('Cannot format as the value cannot be validated.');
+  }
 }

--- a/packages/core/runtime/src/types/BooleanKeyword.ts
+++ b/packages/core/runtime/src/types/BooleanKeyword.ts
@@ -1,5 +1,6 @@
 import Literal from './Literal';
 import { Type, Annotation, usePluginSystem } from '@manta-style/core';
+import { Literals } from '../utils/baseType';
 
 export default class BooleanKeyword extends Type {
   public deriveLiteral(annotations: Annotation[]) {
@@ -15,5 +16,15 @@ export default class BooleanKeyword extends Type {
   }
   public validate(value: unknown): value is any {
     return typeof value === 'boolean';
+  }
+  public format(value: unknown) {
+    if ([1, 'true', 'True', true, 'TRUE'].includes(value as Literals)) {
+      return true;
+    } else if (
+      [0, 'false', 'False', false, 'FALSE', ''].includes(value as Literals)
+    ) {
+      return false;
+    }
+    throw new Error('Cannot format as the value cannot be validated.');
   }
 }

--- a/packages/core/runtime/src/types/BooleanKeyword.ts
+++ b/packages/core/runtime/src/types/BooleanKeyword.ts
@@ -18,11 +18,9 @@ export default class BooleanKeyword extends Type {
     return typeof value === 'boolean';
   }
   public format(value: unknown) {
-    if ([1, 'true', 'True', true, 'TRUE'].includes(value as Literals)) {
+    if ([1, true].includes(value as number)) {
       return true;
-    } else if (
-      [0, 'false', 'False', false, 'FALSE', ''].includes(value as Literals)
-    ) {
+    } else if ([0, false, ''].includes(value as Literals)) {
       return false;
     }
     throw new Error('Cannot format as the value cannot be validated.');

--- a/packages/core/runtime/src/types/ConditionalType.ts
+++ b/packages/core/runtime/src/types/ConditionalType.ts
@@ -74,6 +74,10 @@ export default class ConditionalType extends Type {
     const resolvedType = this.getResolvedType();
     return resolvedType.validate(value);
   }
+  public format(value: unknown) {
+    const resolvedType = this.getResolvedType();
+    return resolvedType.validate(value);
+  }
 }
 
 function resolveConditionalType(

--- a/packages/core/runtime/src/types/IntersectionType.ts
+++ b/packages/core/runtime/src/types/IntersectionType.ts
@@ -8,15 +8,16 @@ export default class IntersectionType extends Type {
     super();
     this.types = types;
   }
+  private getReducedType() {
+    return this.types
+      .map((type) => resolveReferencedType(type).type)
+      .reduce((prev, current) => intersection(prev, current));
+  }
   public deriveLiteral(parentAnnotations: Annotation[]) {
-    const resolvedTypes = this.types.map(
-      (type) => resolveReferencedType(type).type,
-    );
-    let reducedType = resolvedTypes[0];
-    for (const type of resolvedTypes) {
-      reducedType = intersection(reducedType, type);
-    }
-    return reducedType.deriveLiteral(parentAnnotations);
+    return this.getReducedType().deriveLiteral(parentAnnotations);
+  }
+  public format(value: unknown) {
+    return this.getReducedType().format(value);
   }
   public validate(value: unknown): value is any {
     return this.types.every((type) => type.validate(value));

--- a/packages/core/runtime/src/types/KeyOfKeyword.ts
+++ b/packages/core/runtime/src/types/KeyOfKeyword.ts
@@ -27,4 +27,7 @@ export default class KeyOfKeyword extends Type {
     const keys = this.getKeys();
     return typeof value === 'string' && keys.includes(value);
   }
+  public format(value: unknown) {
+    return this.deriveLiteral().format(value);
+  }
 }

--- a/packages/core/runtime/src/types/Literal.ts
+++ b/packages/core/runtime/src/types/Literal.ts
@@ -18,4 +18,10 @@ export default class Literal<T extends Literals | Fetcher<any>> extends Type {
   public mock() {
     return this.literal instanceof Fetcher ? this.literal.read() : this.literal;
   }
+  public format(value: unknown) {
+    if (value == this.literal) {
+      return this.literal;
+    }
+    throw new Error('Cannot format as the value cannot be validated.');
+  }
 }

--- a/packages/core/runtime/src/types/MappedType.ts
+++ b/packages/core/runtime/src/types/MappedType.ts
@@ -77,6 +77,9 @@ export default class MappedType extends Type {
   public validate(value: any): value is any {
     throw Error('MappedType does not support validation yet');
   }
+  public format(value: unknown) {
+    throw new Error('MappedType doesn not support format yet');
+  }
   public TypeParameter(name: string) {
     const newTypeParam = new TypeParameter(name);
     this.typeParameter = newTypeParam;

--- a/packages/core/runtime/src/types/NeverKeyword.ts
+++ b/packages/core/runtime/src/types/NeverKeyword.ts
@@ -7,4 +7,7 @@ export default class NeverKeyword extends Type {
   public validate(value: any): value is never {
     throw new Error('`never` keyword does not support `validate` method.');
   }
+  public format(value: unknown) {
+    throw new Error('Cannot format as the value cannot be validated.');
+  }
 }

--- a/packages/core/runtime/src/types/NullKeyword.ts
+++ b/packages/core/runtime/src/types/NullKeyword.ts
@@ -10,4 +10,10 @@ export default class NullKeyword extends Type {
   public validate(value: unknown): value is null {
     return value === null;
   }
+  public format(value: unknown) {
+    if ([null, 0, '', 'null', 'NULL'].includes(value as null)) {
+      return null;
+    }
+    throw new Error('Cannot format as the value cannot be validated.');
+  }
 }

--- a/packages/core/runtime/src/types/NullableType.ts
+++ b/packages/core/runtime/src/types/NullableType.ts
@@ -20,11 +20,10 @@ export default class NullableType extends Type {
     return this.nullableType.deriveLiteral(annotations);
   }
   public validate(value: unknown): value is any {
-    return (
-      this.type.validate(value) ||
-      MantaStyle.UndefinedKeyword.validate(value) ||
-      MantaStyle.NullKeyword.validate(value)
-    );
+    return this.nullableType.validate(value);
+  }
+  public format(value: unknown) {
+    return this.nullableType.format(value);
   }
   public _getUnderlyingType() {
     return this.type;

--- a/packages/core/runtime/src/types/NumberKeyword.ts
+++ b/packages/core/runtime/src/types/NumberKeyword.ts
@@ -15,4 +15,12 @@ export default class NumberKeyword extends Type {
   public validate(value: unknown): value is number {
     return typeof value === 'number';
   }
+  public format(value: unknown) {
+    if (typeof value === 'number') {
+      return value;
+    } else if (typeof value === 'string' && !isNaN(Number(value))) {
+      return Number(value);
+    }
+    throw new Error('Cannot format as the value cannot be validated.');
+  }
 }

--- a/packages/core/runtime/src/types/ObjectKeyword.ts
+++ b/packages/core/runtime/src/types/ObjectKeyword.ts
@@ -8,4 +8,11 @@ export default class ObjectKeyword extends Type {
   public validate(value: unknown): value is object {
     return typeof value === 'object';
   }
+  public format(value: unknown) {
+    if (typeof value === 'object') {
+      return value;
+    } else {
+      return {};
+    }
+  }
 }

--- a/packages/core/runtime/src/types/OptionalType.ts
+++ b/packages/core/runtime/src/types/OptionalType.ts
@@ -1,18 +1,22 @@
 import { Annotation, Type } from '@manta-style/core';
 import MantaStyle from '..';
+import UnionType from './UnionType';
 
 export default class OptionalType extends Type {
   private type: Type;
+  private optionalType: UnionType;
   constructor(type: Type) {
     super();
     this.type = type;
+    this.optionalType = new UnionType([this.type, MantaStyle.UndefinedKeyword]);
   }
   public deriveLiteral(annotations: Annotation[]) {
     return this.type.deriveLiteral(annotations);
   }
   public validate(value: unknown): value is any {
-    return (
-      this.type.validate(value) || MantaStyle.UndefinedKeyword.validate(value)
-    );
+    return this.optionalType.validate(value);
+  }
+  public format(value: unknown) {
+    return this.optionalType.format(value);
   }
 }

--- a/packages/core/runtime/src/types/ParenthesizedType.ts
+++ b/packages/core/runtime/src/types/ParenthesizedType.ts
@@ -15,4 +15,7 @@ export default class ParenthesizedType extends Type {
   public validate(value: unknown): value is any {
     return this.type.validate(value);
   }
+  public format(value: unknown) {
+    return this.type.format(value);
+  }
 }

--- a/packages/core/runtime/src/types/StringKeyword.ts
+++ b/packages/core/runtime/src/types/StringKeyword.ts
@@ -19,9 +19,6 @@ export default class StringKeyword extends Type {
     return typeof value === 'string';
   }
   public format(value: unknown) {
-    console.log('original:', value);
-    // @ts-ignore
-    console.log('formatted:'.String(value));
     return String(value);
   }
 }

--- a/packages/core/runtime/src/types/StringKeyword.ts
+++ b/packages/core/runtime/src/types/StringKeyword.ts
@@ -18,4 +18,7 @@ export default class StringKeyword extends Type {
   public validate(value: unknown): value is string {
     return typeof value === 'string';
   }
+  public format(value: unknown) {
+    return String(value);
+  }
 }

--- a/packages/core/runtime/src/types/StringKeyword.ts
+++ b/packages/core/runtime/src/types/StringKeyword.ts
@@ -19,6 +19,9 @@ export default class StringKeyword extends Type {
     return typeof value === 'string';
   }
   public format(value: unknown) {
+    console.log('original:', value);
+    // @ts-ignore
+    console.log('formatted:'.String(value));
     return String(value);
   }
 }

--- a/packages/core/runtime/src/types/TupleType.ts
+++ b/packages/core/runtime/src/types/TupleType.ts
@@ -25,14 +25,26 @@ export default class TupleType extends Type {
     }
     return new ArrayLiteral(arrayLiteral);
   }
-  public validate(value: unknown): value is any {
+  private looseValidate(value: unknown): value is any[] {
     // TODO: Calculate the correct length based on OptionalTypes and RestType
     return (
       Array.isArray(value) &&
       value.length >=
         this.elementTypes.filter((type) => !(type instanceof OptionalType))
-          .length &&
+          .length
+    );
+  }
+  public validate(value: unknown): value is any[] {
+    return (
+      this.looseValidate(value) &&
       value.every((item, index) => this.elementTypes[index].validate(item))
     );
+  }
+  public format(value: unknown) {
+    if (this.looseValidate(value)) {
+      return value.map((item, index) => this.elementTypes[index].format(item));
+    } else {
+      throw new Error('Cannot format as the value cannot be validated.');
+    }
   }
 }

--- a/packages/core/runtime/src/types/TypeLiteral.ts
+++ b/packages/core/runtime/src/types/TypeLiteral.ts
@@ -211,12 +211,11 @@ export default class TypeLiteral extends Type {
                 MantaStyle.UndefinedKeyword,
               ]).format(propertyValue)
             : foundProperty.type.format(propertyValue);
-          console.log(shallowCopy);
         } else {
           throw new Error('Cannot format as the value cannot be validated.');
         }
-        return shallowCopy;
       }
+      return shallowCopy;
     }
   }
   public compose(type: TypeLiteral): TypeLiteral {

--- a/packages/core/runtime/src/types/UndefinedKeyword.ts
+++ b/packages/core/runtime/src/types/UndefinedKeyword.ts
@@ -10,4 +10,10 @@ export default class UndefinedKeyword extends Type {
   public validate(value: unknown): value is undefined {
     return typeof value === 'undefined';
   }
+  public format(value: unknown) {
+    if (typeof value === 'undefined') {
+      return value;
+    }
+    throw new Error('Cannot format as the value cannot be validated.');
+  }
 }

--- a/packages/core/runtime/src/types/UnionType.ts
+++ b/packages/core/runtime/src/types/UnionType.ts
@@ -44,6 +44,16 @@ export default class UnionType extends Type {
   public validate(value: unknown): value is any {
     return this.types.some((type) => type.validate(value));
   }
+  public format(value: unknown) {
+    for (const type of this.types) {
+      try {
+        return type.format(value);
+      } catch {
+        // Empty
+      }
+    }
+    throw new Error('Cannot format as the value cannot be validated.');
+  }
   public getTypes(): Type[] {
     return this.types;
   }

--- a/packages/core/runtime/src/types/UnionType.ts
+++ b/packages/core/runtime/src/types/UnionType.ts
@@ -49,8 +49,6 @@ export default class UnionType extends Type {
       try {
         return type.format(value);
       } catch {
-        console.log('cannot format: ', value);
-        console.log('type is ', type);
         // Empty
       }
     }

--- a/packages/core/runtime/src/types/UnionType.ts
+++ b/packages/core/runtime/src/types/UnionType.ts
@@ -49,6 +49,8 @@ export default class UnionType extends Type {
       try {
         return type.format(value);
       } catch {
+        console.log('cannot format: ', value);
+        console.log('type is ', type);
         // Empty
       }
     }

--- a/packages/core/runtime/src/utils/pseudoTypes.ts
+++ b/packages/core/runtime/src/utils/pseudoTypes.ts
@@ -12,6 +12,9 @@ export class ErrorType extends Type {
   public validate(value: any): value is never {
     throw Error('ErrorType does not support `validate` method.');
   }
+  public format(vaue: unknown) {
+    throw Error('ErrorType does not support `format` method.');
+  }
   public mock() {
     throw new Error(this.message);
   }

--- a/packages/servers/server-restful/src/index.ts
+++ b/packages/servers/server-restful/src/index.ts
@@ -4,6 +4,7 @@ import {
   Endpoint,
   HTTPMethods,
   Type,
+  flushFetcher,
 } from '@manta-style/core';
 
 const HTTP_METHODS: HTTPMethods[] = ['get', 'post', 'put', 'patch', 'delete'];
@@ -21,7 +22,8 @@ function isTypeLiteral(type: any): type is TypeLiteral {
 async function restfulServerCallback(matchedEndpoint: Endpoint) {
   const type = typeMapping[generateHashString(matchedEndpoint)];
   if (type) {
-    const literalType = await type.deriveLiteral([]);
+    const literalType = type.deriveLiteral([]);
+    await flushFetcher();
     return literalType.mock();
   }
   throw Error(


### PR DESCRIPTION
This PR adds `format` feature to `Type`s.

For example:
```ts
// type NumberKeyword = number;
const { NumberKeyword } = MantaStyle;

NumberKeyword.format('333'); // Get 333 number
```

`format` function also applies loose validation to the data (instead of strict one `validate`).