### PR TITLE
TypeScript Builder: Create the file (instead of folder only) if the dest file doesn't exist

### DIFF
--- a/packages/builders/builder-typescript/package.json
+++ b/packages/builders/builder-typescript/package.json
@@ -30,6 +30,7 @@
     "@types/babel__generator": "^7.0.1",
     "@types/babel__template": "^7.0.1",
     "@types/babel__traverse": "^7.0.4",
+    "@types/fs-extra": "^5.0.4",
     "@types/glob": "^7.1.1",
     "webpack": "^4.29.0",
     "webpack-cli": "^3.2.1"
@@ -40,6 +41,7 @@
     "@babel/preset-env": "^7.3.1",
     "@manta-style/core": "^0.2.0-alpha.13",
     "@manta-style/test-helpers": "^0.2.0-alpha.13",
+    "fs-extra": "^7.0.1",
     "glob": "^7.1.3",
     "typescript": "^3.2.4"
   },

--- a/packages/builders/builder-typescript/src/utils/build.ts
+++ b/packages/builders/builder-typescript/src/utils/build.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import * as fs from 'fs';
+import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as glob from 'glob';
 import * as babelCore from '@babel/core';
@@ -47,7 +47,7 @@ export default function build({
       sourceFiles,
     ) {
       try {
-        fs.mkdirSync(path.dirname(fileName));
+        fs.ensureFileSync(fileName);
       } catch {
         // Empty
       }


### PR DESCRIPTION
As the title says.